### PR TITLE
TRELLO-1398 fix Datepicker, forbid very distant dates

### DIFF
--- a/src/anomaly/Anomaly.ts
+++ b/src/anomaly/Anomaly.ts
@@ -94,7 +94,7 @@ export interface DetailInput {
   type: DetailInputType
   placeholder?: string
   options?: string[]
-  defaultValue?: string
+  defaultValue?: 'SYSDATE'
   example?: string
   optionnal?: boolean
 }

--- a/src/anomaly/script/checkAnomaliesJson.ts
+++ b/src/anomaly/script/checkAnomaliesJson.ts
@@ -76,7 +76,7 @@ const inputSubcategorySpec: ObjectSpec = {
         type: _ => _.assertIsAllowedString(Object.values(DetailInputType)),
         placeholder: _ => _.ifDefined()?.assertIsString(),
         options: _ => _.ifDefined()?.assertIsArrayOfString(),
-        defaultValue: _ => _.ifDefined()?.assertIsString(),
+        defaultValue: _ => _.ifDefined()?.assertIsAllowedString(['SYSDATE']),
         example: _ => _.ifDefined()?.assertIsString(),
         optionnal: _ => _.ifDefined()?.assertIsBoolean(),
       })

--- a/src/conf/appConfig.ts
+++ b/src/conf/appConfig.ts
@@ -62,8 +62,6 @@ export const appConfig = {
   matomo_siteId: map()(Env.NEXT_PUBLIC_MATOMO_SITE_ID),
   matomo_url: map()(Env.NEXT_PUBLIC_MATOMO_URL),
   useHashRouter: true,
-  apiDateFormat: 'dd/MM/yyyy',
-  browserDateFormat: 'yyyy-MM-dd',
   maxDescriptionInputLength: 1000,
   infoBanner: map()(Env.NEXT_PUBLIC_INFO_BANNER),
   infoBannerOnMobile: map(bool, defaultValue(false))(Env.NEXT_PUBLIC_INFO_BANNER_ON_MOBILE),

--- a/src/core/helper/utils.ts
+++ b/src/core/helper/utils.ts
@@ -1,1 +1,31 @@
+import {format, parse} from 'date-fns'
+
 export const isServerSide = () => typeof window === 'undefined'
+
+// dd/mm/yyyy to yyyy-mm-dd
+// We don't use date-fns here, because we have problems
+// with dates with five digits year (dd/mm/YYYYY)
+// which can happen when the user is typing.
+// It's safer to do it manually
+export const frenchToIsoFormat = (d: string) => {
+  return d.split('/').reverse().join('-')
+}
+
+// yyyy-mm-dd to dd/mm/yyyy
+export const isoToFrenchFormat = (d: string) => {
+  return d.split('-').reverse().join('/')
+}
+
+export const dateToFrenchFormat = (d: Date) => {
+  return format(d, frenchDateFormat)
+}
+
+export const frenchFormatToDate = (d: string) => {
+  return parse(d, frenchDateFormat, new Date())
+}
+
+export const isDateInRange = (d: string, min: string, max: string) => {
+  return frenchFormatToDate(d) >= frenchFormatToDate(min) && frenchFormatToDate(d) <= frenchFormatToDate(max)
+}
+
+export const frenchDateFormat = 'dd/MM/yyyy'

--- a/src/core/i18n/localization/fr.ts
+++ b/src/core/i18n/localization/fr.ts
@@ -74,6 +74,7 @@ export const fr = {
     anErrorOccurred: "Une erreur s'est produite.",
     minimize: 'Minimize',
     required: 'Requis',
+    invalidDate: 'Date invalide',
     cancel: 'Annuler',
     help: 'Aide',
     created_at: 'Créé le',

--- a/src/feature/Playground/PlaygroundDetails.tsx
+++ b/src/feature/Playground/PlaygroundDetails.tsx
@@ -24,8 +24,21 @@ export class DetailsFixtureInput {
   static readonly date: DetailInput = {
     label: 'Date label',
     rank: 2,
+    type: DetailInputType.DATE,
+    defaultValue: 'SYSDATE',
+  }
+
+  static readonly dateNotInFuture: DetailInput = {
+    label: 'Date (not in future) label',
+    rank: 2,
     type: DetailInputType.DATE_NOT_IN_FUTURE,
     defaultValue: 'SYSDATE',
+  }
+
+  static readonly dateWithNoDefault: DetailInput = {
+    label: 'Date (without default to SYSDATE) label',
+    rank: 2,
+    type: DetailInputType.DATE,
   }
 
   static readonly radio: DetailInput = {
@@ -62,6 +75,8 @@ export const PlaygroundDetails = () => {
   const config = {
     text: DetailsFixtureInput.text,
     date: DetailsFixtureInput.date,
+    dateNotInFuture: DetailsFixtureInput.dateNotInFuture,
+    dateWithNoDefault: DetailsFixtureInput.dateWithNoDefault,
     radio: DetailsFixtureInput.radio,
     checkbox: DetailsFixtureInput.checkbox,
     textarea: DetailsFixtureInput.textarea,
@@ -70,6 +85,8 @@ export const PlaygroundDetails = () => {
   const [picked, setPicked]: any = useState({
     text: true,
     date: true,
+    dateNotInFuture: true,
+    dateWithNoDefault: true,
     radio: true,
     checkbox: true,
     textarea: true,

--- a/src/feature/Report/Details/Details.test.tsx
+++ b/src/feature/Report/Details/Details.test.tsx
@@ -11,6 +11,7 @@ import {DetailsFixtureInput, DetailsFixtureValue} from 'feature/Playground/Playg
 import {waitFor} from '@testing-library/dom'
 import {mapFor} from '../../../alexlibs/ts-utils'
 import {DetailInputValues2} from 'core/model/ReportDraft'
+import {frenchDateFormat} from 'core/helper/utils'
 
 const clickBtnSubmit = async (app: ScRenderResult) => {
   const btnSubmit = app.container.querySelector('#btn-submit') as HTMLButtonElement
@@ -57,20 +58,19 @@ describe('Details: single date not in future', () => {
     clickBtnSubmit(app)
     await waitFor(() =>
       expect(inputValues).toEqual({
-        0: format(new Date(), appConfig.apiDateFormat),
+        0: format(new Date(), frenchDateFormat),
       }),
     )
   })
 
   it('should update stored reportDraft on submit', async () => {
-    const date = new Date('2018-02-02')
     fireEvent.change(app.container.querySelector('input[type=date]')!, {
-      target: {value: format(date, appConfig.browserDateFormat)},
+      target: {value: '2018-02-15'},
     })
     clickBtnSubmit(app)
     await waitFor(() =>
       expect(inputValues).toEqual({
-        0: format(date, appConfig.apiDateFormat),
+        0: '15/02/2018',
       }),
     )
   })
@@ -179,8 +179,8 @@ describe('Details: textarea', () => {
 describe('Details: initialize values', () => {
   let app: ScRenderResult
   let inputValues: undefined | DetailInputValues2
-  const values = {
-    0: DetailsFixtureValue.date,
+  const initialValues = {
+    0: '01/01/2018',
     1: DetailsFixtureValue.text,
     2: DetailsFixtureValue.radio,
     [SpecifyFormUtils.getInputName(2)]: 'blabla radio',
@@ -192,7 +192,7 @@ describe('Details: initialize values', () => {
     inputValues = undefined
     app = render(
       <_Details
-        initialValues={values}
+        initialValues={initialValues}
         inputs={[
           DetailsFixtureInput.date,
           DetailsFixtureInput.text,
@@ -210,6 +210,8 @@ describe('Details: initialize values', () => {
   it('should submit and send the initial values', async () => {
     await clickBtnSubmit(app)
     hasErrors(app, 0)
-    await waitFor(() => expect(inputValues).toEqual(values))
+    await waitFor(() => {
+      expect(inputValues).toEqual(initialValues)
+    })
   })
 })

--- a/src/shared/Datepicker/Datepicker.test.tsx
+++ b/src/shared/Datepicker/Datepicker.test.tsx
@@ -1,31 +1,27 @@
 /**
  * @jest-environment jsdom
  */
-import React from 'react'
+import {waitFor} from '@testing-library/dom'
 import '@testing-library/jest-dom'
 import {fireEvent, render} from 'test/test-utils'
-import {format} from 'date-fns'
 import {ScDatepicker} from './Datepicker'
-import {appConfig} from '../../conf/appConfig'
-import {waitFor} from '@testing-library/dom'
 
 describe('DatePicker', () => {
   it('should emit and event with a details object containing form inputs when no errors', async () => {
-    const newDate = new Date('2018-02-02')
-    let value: Date | undefined
+    let value: string | undefined
     const app = render(
       <ScDatepicker
-        value={value}
-        onChange={(date: Date) => {
-          value = date
+        value={undefined}
+        onChange={v => {
+          value = v
         }}
       />,
     )
     await waitFor(() => {
       fireEvent.change(app.container.querySelector('input[type=date]')!, {
-        target: {value: format(newDate, appConfig.browserDateFormat)},
+        target: {value: '2017-04-10'},
       })
-      expect(value!.toString()).toEqual(newDate.toString())
+      expect(value).toEqual('10/04/2017')
     })
   })
 })

--- a/src/shared/Datepicker/Datepicker.tsx
+++ b/src/shared/Datepicker/Datepicker.tsx
@@ -1,28 +1,17 @@
-import {format} from 'date-fns'
-import {InputProps as StandardInputProps} from '@mui/material'
-import React, {forwardRef} from 'react'
 import {BaseTextFieldProps} from '@mui/material/TextField/TextField'
+import {frenchToIsoFormat, isoToFrenchFormat} from 'core/helper/utils'
+import React, {forwardRef} from 'react'
 import {ScInput} from '../Input/ScInput'
 
+// /!\ In this datepicker every date (input and output)
+// is a string in the french format dd/mm/yyyy
 export interface ScDatepickerProps extends BaseTextFieldProps {
-  value?: Date
-  onChange?: (_: Date) => void
-  label?: string
-  InputProps?: Partial<StandardInputProps>
+  value?: string
+  onChange: (_: string) => void
+  // These are only indicative
+  // The user can always go around these limits by typing a date manually instead of using the picker
   min?: string
   max?: string
-}
-
-const onChangeDate = (callback: (date: Date) => any) => (e: React.ChangeEvent<HTMLInputElement>) => {
-  callback(new Date(e.target.valueAsDate!))
-}
-
-const mapDate = (date: Date): string => {
-  try {
-    return format(date, 'yyyy-MM-dd')
-  } catch (e: any) {
-    return format(new Date(), 'yyyy-MM-dd')
-  }
 }
 
 export const ScDatepicker = forwardRef(({value, onChange, min, max, ...props}: ScDatepickerProps, ref: any) => {
@@ -30,13 +19,15 @@ export const ScDatepicker = forwardRef(({value, onChange, min, max, ...props}: S
     <ScInput
       inputRef={ref}
       inputProps={{
-        max: max,
-        min: min,
+        ...(max && {max: frenchToIsoFormat(max)}),
+        ...(min && {min: frenchToIsoFormat(min)}),
       }}
       {...props}
       type="date"
-      value={value ? mapDate(value) : ''}
-      onChange={onChange ? onChangeDate(onChange) : undefined}
+      value={value ? frenchToIsoFormat(value) : ''}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(isoToFrenchFormat(e.target.value))
+      }}
       InputLabelProps={{shrink: true}}
     />
   )


### PR DESCRIPTION
- forbid very distant dates, which are likely a typo (ex: 01/01/0022). Nothing outside of 1970 to 2100
- to do that we had to rewrite quite a bit of the Datepicker, it was a mess between the Date and the strings. Now the Datepicker uses only strings, only in one specific format.