### PR TITLE
MEP (reapply : Disable persistence of ReportDraft in localStorage)

### DIFF
--- a/src/feature/Report/ReportFlowContext.tsx
+++ b/src/feature/Report/ReportFlowContext.tsx
@@ -1,4 +1,4 @@
-import React, {Dispatch, ReactNode, SetStateAction, useContext} from 'react'
+import React, {Dispatch, ReactNode, SetStateAction, useContext, useState} from 'react'
 import {usePersistentState} from '../../alexlibs/react-persistent-state'
 import {ReportDraft2} from 'core/model/ReportDraft'
 import {useFetcher} from '../../alexlibs/react-hooks-lib'
@@ -22,17 +22,16 @@ interface ReportFlowProviderProps {
 
 export const ReportFlowProvider = ({initialReport, children}: ReportFlowProviderProps) => {
   const {apiSdk} = useApiSdk()
-  const [reportDraft, setReportDraft, clearReportDraft] = usePersistentState<Partial<ReportDraft2>>(
-    initialReport ?? {},
-    'report-draft',
-  )
+  const [reportDraft, setReportDraft] = useState<Partial<ReportDraft2>>(initialReport ?? {})
   const createReport = useFetcher(apiSdk.report.create)
   return (
     <ReportFlowContext.Provider
       value={{
         reportDraft,
         setReportDraft,
-        clearReportDraft,
+        clearReportDraft: () => {
+          setReportDraft({})
+        },
         createReport,
       }}
     >


### PR DESCRIPTION
There are a bunch of Sentry bugs where some fields of the ReportDraft are missing. I'm thinking it's consistency problem between all the load()/save() performed on the localStorage, at some point some stale data must be loaded and we lose some fields.
Let's try to disable entirely the save in localstorage for the report draft, to see if the Sentry bugs get better.