### PR TITLE
Adjust the shape/type of "detailInputs"

### DIFF
--- a/src/anomaly/Anomaly.ts
+++ b/src/anomaly/Anomaly.ts
@@ -96,6 +96,5 @@ export interface DetailInput {
   placeholder?: string
   options?: string[]
   defaultValue?: 'SYSDATE'
-  example?: string
   optionnal?: boolean
 }

--- a/src/anomaly/Anomaly.ts
+++ b/src/anomaly/Anomaly.ts
@@ -90,11 +90,28 @@ export enum DetailInputType {
   TEXTAREA = 'TEXTAREA',
 }
 
-export interface DetailInput {
+interface DetailInputBase {
   label: string
   type: DetailInputType
-  placeholder?: string
-  options?: string[]
-  defaultValue?: 'SYSDATE'
   optional?: boolean
 }
+
+export type DetailInput = DetailInputBase &
+  (
+    | {
+        type: DetailInputType.TEXT | DetailInputType.TEXTAREA
+        placeholder?: string
+      }
+    | {
+        type: DetailInputType.DATE | DetailInputType.DATE_NOT_IN_FUTURE
+        defaultValue?: 'SYSDATE'
+      }
+    | {
+        type: DetailInputType.RADIO | DetailInputType.CHECKBOX
+        options?: string[]
+      }
+    | {
+        type: DetailInputType.TIMESLOT
+        options?: string[]
+      }
+  )

--- a/src/anomaly/Anomaly.ts
+++ b/src/anomaly/Anomaly.ts
@@ -96,22 +96,39 @@ interface DetailInputBase {
   optional?: boolean
 }
 
-export type DetailInput = DetailInputBase &
-  (
-    | {
-        type: DetailInputType.TEXT | DetailInputType.TEXTAREA
-        placeholder?: string
-      }
-    | {
-        type: DetailInputType.DATE | DetailInputType.DATE_NOT_IN_FUTURE
-        defaultValue?: 'SYSDATE'
-      }
-    | {
-        type: DetailInputType.RADIO | DetailInputType.CHECKBOX
-        options?: string[]
-      }
-    | {
-        type: DetailInputType.TIMESLOT
-        options?: string[]
-      }
-  )
+export type DetailInputText = DetailInputBase & {
+  type: DetailInputType.TEXT
+  placeholder?: string
+}
+export type DetailInputTextarea = DetailInputBase & {
+  type: DetailInputType.TEXTAREA
+  placeholder?: string
+}
+export type DetailInputDate = DetailInputBase & {
+  type: DetailInputType.DATE
+  defaultValue?: 'SYSDATE'
+}
+export type DetailInputDateNotInFuture = DetailInputBase & {
+  type: DetailInputType.DATE_NOT_IN_FUTURE
+  defaultValue?: 'SYSDATE'
+}
+export type DetailInputRadio = DetailInputBase & {
+  type: DetailInputType.RADIO
+  options: string[]
+}
+export type DetailInputCheckbox = DetailInputBase & {
+  type: DetailInputType.CHECKBOX
+  options: string[]
+}
+export type DetailInputTimeslot = DetailInputBase & {
+  type: DetailInputType.TIMESLOT
+}
+
+export type DetailInput =
+  | DetailInputText
+  | DetailInputTextarea
+  | DetailInputDate
+  | DetailInputDateNotInFuture
+  | DetailInputRadio
+  | DetailInputCheckbox
+  | DetailInputTimeslot

--- a/src/anomaly/Anomaly.ts
+++ b/src/anomaly/Anomaly.ts
@@ -96,5 +96,5 @@ export interface DetailInput {
   placeholder?: string
   options?: string[]
   defaultValue?: 'SYSDATE'
-  optionnal?: boolean
+  optional?: boolean
 }

--- a/src/anomaly/Anomaly.ts
+++ b/src/anomaly/Anomaly.ts
@@ -92,8 +92,6 @@ export enum DetailInputType {
 
 export interface DetailInput {
   label: string
-  /** @deprecated */
-  rank?: number
   type: DetailInputType
   placeholder?: string
   options?: string[]

--- a/src/anomaly/script/checkAnomaliesJson.ts
+++ b/src/anomaly/script/checkAnomaliesJson.ts
@@ -72,7 +72,7 @@ const inputSubcategorySpec: ObjectSpec = {
         placeholder: _ => _.ifDefined()?.assertIsString(),
         options: _ => _.ifDefined()?.assertIsArrayOfString(),
         defaultValue: _ => _.ifDefined()?.assertIsAllowedString(['SYSDATE']),
-        optionnal: _ => _.ifDefined()?.assertIsBoolean(),
+        optional: _ => _.ifDefined()?.assertIsBoolean(),
       })
     }),
   ...baseSubcategorySpec,

--- a/src/anomaly/script/checkAnomaliesJson.ts
+++ b/src/anomaly/script/checkAnomaliesJson.ts
@@ -72,7 +72,6 @@ const inputSubcategorySpec: ObjectSpec = {
         placeholder: _ => _.ifDefined()?.assertIsString(),
         options: _ => _.ifDefined()?.assertIsArrayOfString(),
         defaultValue: _ => _.ifDefined()?.assertIsAllowedString(['SYSDATE']),
-        example: _ => _.ifDefined()?.assertIsString(),
         optionnal: _ => _.ifDefined()?.assertIsBoolean(),
       })
     }),

--- a/src/anomaly/script/checkAnomaliesJson.ts
+++ b/src/anomaly/script/checkAnomaliesJson.ts
@@ -68,7 +68,6 @@ const inputSubcategorySpec: ObjectSpec = {
     _.ifDefined()?.assertIsArrayWith(detailInput => {
       detailInput.assertIsObjectWith({
         label: _ => _.assertIsString(),
-        rank: _ => _.ifDefined()?.assertIsNumber(),
         type: _ => _.assertIsAllowedString(Object.values(DetailInputType)),
         placeholder: _ => _.ifDefined()?.assertIsString(),
         options: _ => _.ifDefined()?.assertIsArrayOfString(),

--- a/src/anomaly/script/checkAnomaliesJson.ts
+++ b/src/anomaly/script/checkAnomaliesJson.ts
@@ -66,14 +66,7 @@ const inputSubcategorySpec: ObjectSpec = {
   fileLabel: _ => _.ifDefined()?.assertIsString(),
   detailInputs: _ =>
     _.ifDefined()?.assertIsArrayWith(detailInput => {
-      detailInput.assertIsObjectWith({
-        label: _ => _.assertIsString(),
-        type: _ => _.assertIsAllowedString(Object.values(DetailInputType)),
-        placeholder: _ => _.ifDefined()?.assertIsString(),
-        options: _ => _.ifDefined()?.assertIsArrayOfString(),
-        defaultValue: _ => _.ifDefined()?.assertIsAllowedString(['SYSDATE']),
-        optional: _ => _.ifDefined()?.assertIsBoolean(),
-      })
+      assertIsDetailInput(detailInput)
     }),
   ...baseSubcategorySpec,
 }
@@ -85,4 +78,40 @@ function assertIsSubcategory(subcategory: AnomalyTreeWalker) {
   } else {
     subcategory.assertIsObjectWith(inputSubcategorySpec)
   }
+}
+
+function assertIsDetailInput(detailInput: AnomalyTreeWalker) {
+  const baseSpec: ObjectSpec = {
+    label: _ => _.assertIsString(),
+    type: _ => _.assertIsAllowedString(Object.values(DetailInputType)),
+    optional: _ => _.ifDefined()?.assertIsBoolean(),
+  }
+
+  function getRestOfSpec(): ObjectSpec {
+    switch (detailInput.into('type').value) {
+      case DetailInputType.TEXT:
+      case DetailInputType.TEXTAREA:
+        return {
+          placeholder: _ => _.ifDefined()?.assertIsString(),
+        }
+      case DetailInputType.DATE:
+      case DetailInputType.DATE_NOT_IN_FUTURE:
+        return {
+          defaultValue: _ => _.ifDefined()?.assertIsAllowedString(['SYSDATE']),
+        }
+      case DetailInputType.RADIO:
+      case DetailInputType.CHECKBOX:
+        return {
+          options: _ => _.assertIsArrayOfString(),
+        }
+      case DetailInputType.TIMESLOT:
+      default:
+        return {}
+    }
+  }
+
+  detailInput.assertIsObjectWith({
+    ...baseSpec,
+    ...getRestOfSpec(),
+  })
 }

--- a/src/anomaly/yml/common/date.yml
+++ b/src/anomaly/yml/common/date.yml
@@ -18,11 +18,9 @@
         - '323'
       detailInputs:
         - label: Date du constat (ou d'achat suivant le cas)
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Date Limite de Consommation (DLC)
-          rank: 2
           type: DATE
       fileLabel: Photo de la DLC / du produit / de la marque
     - title: Non
@@ -39,16 +37,13 @@
     - '323'
   detailInputs:
     - label: Quel est le problème ?
-      rank: 1
       type: RADIO
       options:
         - La date est dépassée
         - La date sera dépassée d'ici 7 jours
     - label: Date de consommation recommandée
-      rank: 2
       type: DATE
     - label: Date du constat (ou date d'achat)
-      rank: 3
       type: DATE
       defaultValue: SYSDATE
   fileLabel: Photo

--- a/src/anomaly/yml/common/garantie.yml
+++ b/src/anomaly/yml/common/garantie.yml
@@ -10,24 +10,19 @@
         - title: Il y a moins de 2 ans
           detailInputs:
             - label: Date d'achat
-              rank: 1
               type: DATE
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Date du constat
-              rank: 3
               type: DATE
               defaultValue: SYSDATE
             - label: Interlocuteur
-              rank: 4
               type: RADIO
               options:
                 - Vendeur
                 - Accueil magasin
                 - Service client (téléphone, mail, courrier)
             - label: Pour quelle raison le commerçant ne veut pas vous reprendre le produit&#160;?
-              rank: 5
               type: TEXTAREA
           fileLabel: Preuve d'achat / publicité / offre de vente
         - title: Il y a plus de 2 ans
@@ -41,20 +36,15 @@
                 - title: J'ai pris connaissance des conditions écrites dans mon contrat de garantie
                   detailInputs:
                     - label: Date d'achat
-                      rank: 1
                       type: DATE
                     - label: Nom du produit
-                      rank: 2
                       type: TEXT
                     - label: Date de fin de garantie supplémentaire
-                      rank: 3
                       type: DATE
                     - label: Date du constat
-                      rank: 4
                       type: DATE
                       defaultValue: SYSDATE
                     - label: Motif de refus
-                      rank: 5
                       type: TEXT
                   fileLabel: Contrat de garantie / publicité de l'offre de vente / document se référant à la garantie
             - title: Non
@@ -78,24 +68,19 @@
         - title: Il y a moins de 6 mois
           detailInputs:
             - label: Date d'achat
-              rank: 1
               type: DATE
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Date du constat
-              rank: 3
               type: DATE
               defaultValue: SYSDATE
             - label: Interlocuteur
-              rank: 4
               type: RADIO
               options:
                 - Vendeur
                 - Accueil magasin
                 - Service client (téléphone, mail, courrier)
             - label: Pour quelle raison le commerçant ne veut pas vous reprendre  le produit&#160;?
-              rank: 5
               type: TEXTAREA
           fileLabel: Preuve d'achat / publicité / offre de vente
         - title: Il y a plus de 6 mois
@@ -109,20 +94,15 @@
                 - title: J'ai pris connaissance des conditions écrites dans mon contrat de garantie
                   detailInputs:
                     - label: Date d'achat
-                      rank: 1
                       type: DATE
                     - label: Nom du produit
-                      rank: 2
                       type: TEXT
                     - label: Date de fin de garantie supplémentaire
-                      rank: 3
                       type: DATE
                     - label: Date du constat
-                      rank: 4
                       type: DATE
                       defaultValue: SYSDATE
                     - label: Motif de refus
-                      rank: 5
                       type: TEXT
                   fileLabel: Contrat de garantie / publicité de l'offre de vente / document se référant à la garantie
             - title: Non

--- a/src/anomaly/yml/common/inputs/bloctel.yml
+++ b/src/anomaly/yml/common/inputs/bloctel.yml
@@ -1,20 +1,15 @@
 - label: Date de l'appel
-  rank: 1
   type: DATE
   defaultValue: SYSDATE
 - label: Heure de l'appel
-  rank: 2
   type: TIMESLOT
 - label: Votre numéro de téléphone
-  rank: 3
   type: TEXT
 - label: Votre numéro d'inscription bloctel (recommandé)
   example: Ce numéro est présent dans toutes les confirmations – inscription initiale, dépôts de réclamation – que vous a envoyés Bloctel
-  rank: 4
   type: TEXT
   optionnal: true
 - label: L'appel concernait
-  rank: 5
   type: RADIO
   options:
     - Banque / Assurance / Mutuelle
@@ -33,7 +28,6 @@
     - Équipement pour maison (ameublement, électroménager, ...)
     - Autre
 - label: "Le vendeur s'est fait passer pour:"
-  rank: 6
   type: RADIO
   options:
     - Administration

--- a/src/anomaly/yml/common/inputs/bloctel.yml
+++ b/src/anomaly/yml/common/inputs/bloctel.yml
@@ -7,7 +7,7 @@
   type: TEXT
 - label: Votre numéro d'inscription bloctel (recommandé)
   type: TEXT
-  optionnal: true
+  optional: true
 - label: L'appel concernait
   type: RADIO
   options:

--- a/src/anomaly/yml/common/inputs/bloctel.yml
+++ b/src/anomaly/yml/common/inputs/bloctel.yml
@@ -6,7 +6,6 @@
 - label: Votre numéro de téléphone
   type: TEXT
 - label: Votre numéro d'inscription bloctel (recommandé)
-  example: Ce numéro est présent dans toutes les confirmations – inscription initiale, dépôts de réclamation – que vous a envoyés Bloctel
   type: TEXT
   optionnal: true
 - label: L'appel concernait

--- a/src/anomaly/yml/common/inputs/influenceur.yml
+++ b/src/anomaly/yml/common/inputs/influenceur.yml
@@ -4,7 +4,7 @@
 - label: Nom du produit ou du service (facultatif)
   type: TEXT
   placeholder: Préciser la nature et la gravité
-  optionnal: true
+  optional: true
 - label: Pouvez-vous préciser la plateforme utilisée ?
   type: RADIO
   options:

--- a/src/anomaly/yml/common/inputs/influenceur.yml
+++ b/src/anomaly/yml/common/inputs/influenceur.yml
@@ -1,14 +1,11 @@
 - label: Nom ou pseudonyme de l'influenceur ou influenceuse
-  rank: 1
   type: TEXT
   placeholder: Nom ou pseudonyme
 - label: Nom du produit ou du service (facultatif)
-  rank: 2
   type: TEXT
   placeholder: Préciser la nature et la gravité
   optionnal: true
 - label: Pouvez-vous préciser la plateforme utilisée ?
-  rank: 3
   type: RADIO
   options:
     - Youtube

--- a/src/anomaly/yml/common/inputs/intoxication-alimentaire.yml
+++ b/src/anomaly/yml/common/inputs/intoxication-alimentaire.yml
@@ -1,16 +1,13 @@
 - label: Date de l'accident
-  rank: 1
   type: DATE
   defaultValue: SYSDATE
 - label: Avez-vous été la seule personne malade ?&#160;?
-  rank: 2
   optionnal: true
   type: RADIO
   options:
     - Non (à préciser)
     - Oui
 - label: Avez-vous consulté un médecin&#160;?
-  rank: 3
   optionnal: true
   type: RADIO
   example: Précisez si vous avez eu un arrêt de travail et sa durée
@@ -18,11 +15,9 @@
     - Non
     - Oui (à préciser)
 - label: Décrivez nous plus en détails ce qui s'est passé
-  rank: 4
   type: TEXTAREA
   example: Pensez à donner le nom de vos plats ou du produit consommé
 - label: Avez-vous déjà contacté le restaurateur ou le fabriquant pour ce problème&#160;?
-  rank: 7
   type: RADIO
   options:
     - Oui

--- a/src/anomaly/yml/common/inputs/intoxication-alimentaire.yml
+++ b/src/anomaly/yml/common/inputs/intoxication-alimentaire.yml
@@ -2,13 +2,13 @@
   type: DATE
   defaultValue: SYSDATE
 - label: Avez-vous été la seule personne malade ?&#160;?
-  optionnal: true
+  optional: true
   type: RADIO
   options:
     - Non (à préciser)
     - Oui
 - label: Avez-vous consulté un médecin&#160;?
-  optionnal: true
+  optional: true
   type: RADIO
   options:
     - Non

--- a/src/anomaly/yml/common/inputs/intoxication-alimentaire.yml
+++ b/src/anomaly/yml/common/inputs/intoxication-alimentaire.yml
@@ -10,13 +10,11 @@
 - label: Avez-vous consulté un médecin&#160;?
   optionnal: true
   type: RADIO
-  example: Précisez si vous avez eu un arrêt de travail et sa durée
   options:
     - Non
     - Oui (à préciser)
 - label: Décrivez nous plus en détails ce qui s'est passé
   type: TEXTAREA
-  example: Pensez à donner le nom de vos plats ou du produit consommé
 - label: Avez-vous déjà contacté le restaurateur ou le fabriquant pour ce problème&#160;?
   type: RADIO
   options:

--- a/src/anomaly/yml/common/inputs/produit-alimentaire.yml
+++ b/src/anomaly/yml/common/inputs/produit-alimentaire.yml
@@ -1,21 +1,16 @@
 - label: Date de l'accident
-  rank: 1
   type: DATE
   defaultValue: SYSDATE
 - label: Nom du produit
-  rank: 2
   type: TEXT
 - label: Marque / adresse du fabriquant
   example: Indiquée sur l'emballage
-  rank: 3
   optionnal: true
   type: TEXT
 - label: Élements d'identification (Modèle / N° de série / Volume / Poids)
-  rank: 4
   optionnal: true
   type: TEXT
 - label: La personne qui a consommé l'aliment est-elle tombée malade et/ou s'est-elle blessée&#160;?
-  rank: 5
   optionnal: true
   type: RADIO
   example: Préciser la nature et la gravité
@@ -23,10 +18,8 @@
     - Non
     - Oui (à préciser)
 - label: Décrivez nous plus en détails ce qui s'est passé
-  rank: 6
   type: TEXTAREA
 - label: Avez-vous déjà contacté le commerçant ou le fabriquant pour ce problème&#160;?
-  rank: 7
   type: RADIO
   options:
     - Oui

--- a/src/anomaly/yml/common/inputs/produit-alimentaire.yml
+++ b/src/anomaly/yml/common/inputs/produit-alimentaire.yml
@@ -4,13 +4,13 @@
 - label: Nom du produit
   type: TEXT
 - label: Marque / adresse du fabriquant
-  optionnal: true
+  optional: true
   type: TEXT
 - label: Élements d'identification (Modèle / N° de série / Volume / Poids)
-  optionnal: true
+  optional: true
   type: TEXT
 - label: La personne qui a consommé l'aliment est-elle tombée malade et/ou s'est-elle blessée&#160;?
-  optionnal: true
+  optional: true
   type: RADIO
   options:
     - Non

--- a/src/anomaly/yml/common/inputs/produit-alimentaire.yml
+++ b/src/anomaly/yml/common/inputs/produit-alimentaire.yml
@@ -4,7 +4,6 @@
 - label: Nom du produit
   type: TEXT
 - label: Marque / adresse du fabriquant
-  example: Indiquée sur l'emballage
   optionnal: true
   type: TEXT
 - label: Élements d'identification (Modèle / N° de série / Volume / Poids)
@@ -13,7 +12,6 @@
 - label: La personne qui a consommé l'aliment est-elle tombée malade et/ou s'est-elle blessée&#160;?
   optionnal: true
   type: RADIO
-  example: Préciser la nature et la gravité
   options:
     - Non
     - Oui (à préciser)

--- a/src/anomaly/yml/common/inputs/produit-dangereux.yml
+++ b/src/anomaly/yml/common/inputs/produit-dangereux.yml
@@ -4,13 +4,13 @@
 - label: Nom du produit
   type: TEXT
 - label: Marque / adresse du fabriquant
-  optionnal: true
+  optional: true
   type: TEXT
 - label: Élements d'identification (Modèle / N° de série / Volume / Poids)
-  optionnal: true
+  optional: true
   type: TEXT
 - label: La personne qui a utilisé le produit a-t-elle était blessée&#160;?
-  optionnal: true
+  optional: true
   type: RADIO
   options:
     - Non

--- a/src/anomaly/yml/common/inputs/produit-dangereux.yml
+++ b/src/anomaly/yml/common/inputs/produit-dangereux.yml
@@ -4,7 +4,6 @@
 - label: Nom du produit
   type: TEXT
 - label: Marque / adresse du fabriquant
-  example: Indiquée sur l'emballage
   optionnal: true
   type: TEXT
 - label: Élements d'identification (Modèle / N° de série / Volume / Poids)
@@ -13,7 +12,6 @@
 - label: La personne qui a utilisé le produit a-t-elle était blessée&#160;?
   optionnal: true
   type: RADIO
-  example: Préciser la nature et la gravité
   options:
     - Non
     - Oui (à préciser)

--- a/src/anomaly/yml/common/inputs/produit-dangereux.yml
+++ b/src/anomaly/yml/common/inputs/produit-dangereux.yml
@@ -1,21 +1,16 @@
 - label: Date de l'accident
-  rank: 1
   type: DATE
   defaultValue: SYSDATE
 - label: Nom du produit
-  rank: 2
   type: TEXT
 - label: Marque / adresse du fabriquant
   example: Indiquée sur l'emballage
-  rank: 3
   optionnal: true
   type: TEXT
 - label: Élements d'identification (Modèle / N° de série / Volume / Poids)
-  rank: 4
   optionnal: true
   type: TEXT
 - label: La personne qui a utilisé le produit a-t-elle était blessée&#160;?
-  rank: 5
   optionnal: true
   type: RADIO
   example: Préciser la nature et la gravité
@@ -23,10 +18,8 @@
     - Non
     - Oui (à préciser)
 - label: Décrivez nous plus en détails ce qui s'est passé
-  rank: 6
   type: TEXTAREA
 - label: Avez-vous déjà contacté le commerçant ou le fabriquant pour ce problème&#160;?
-  rank: 7
   type: RADIO
   options:
     - Oui

--- a/src/anomaly/yml/common/inputs/retrait-rappel.yml
+++ b/src/anomaly/yml/common/inputs/retrait-rappel.yml
@@ -3,7 +3,7 @@
   defaultValue: SYSDATE
 - label: Heure du constat
   type: TIMESLOT
-  optionnal: true
+  optional: true
 - label: Nom du produit / marque
   type: TEXT
 - label: Numéro de lot / référence

--- a/src/anomaly/yml/common/inputs/retrait-rappel.yml
+++ b/src/anomaly/yml/common/inputs/retrait-rappel.yml
@@ -1,17 +1,12 @@
 - label: Date du constat
-  rank: 1
   type: DATE_NOT_IN_FUTURE
   defaultValue: SYSDATE
 - label: Heure du constat
-  rank: 2
   type: TIMESLOT
   optionnal: true
 - label: Nom du produit / marque
-  rank: 3
   type: TEXT
 - label: Numéro de lot / référence
-  rank: 4
   type: TEXT
 - label: Qu'avez-vous constaté&#160;?
-  rank: 5
   type: TEXTAREA

--- a/src/anomaly/yml/common/nourriture.yml
+++ b/src/anomaly/yml/common/nourriture.yml
@@ -57,11 +57,9 @@
                 - '323'
               detailInputs:
                 - label: Date du constat (ou d'achat suivant le cas)
-                  rank: 1
                   type: DATE_NOT_IN_FUTURE
                   defaultValue: SYSDATE
                 - label: Date Limite de Consommation (DLC)
-                  rank: 2
                   type: DATE
               fileLabel: Photo de la DLC / du produit / de la marque
             - title: Non
@@ -79,16 +77,13 @@
             - '323'
           detailInputs:
             - label: Quel est le problème ?
-              rank: 1
               type: RADIO
               options:
                 - La date est dépassée
                 - La date sera dépassée d'ici 7 jours
             - label: Date de consommation recommandée
-              rank: 2
               type: DATE
             - label: Date du constat (ou date d'achat)
-              rank: 3
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo
@@ -106,10 +101,8 @@
           example: 'Exemple : pizza dans une boulangerie, plat dans un restaurant'
           detailInputs:
             - label: Nom du produit
-              rank: 1
               type: TEXT
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 2
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo du produit
@@ -117,29 +110,23 @@
           example: "Exemple : bouteille d'eau, conserve de légumes, paquet de chips"
           detailInputs:
             - label: "C'est un produit vendu&#160;:"
-              rank: 1
               type: RADIO
               options:
                 - au rayon frais
                 - au rayon surgelé
                 - à température ambiante
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Marque
-              rank: 3
               type: TEXT
             - label: Numéro de lot (si possible)
-              rank: 4
               type: TEXT
               placeholder: Il est imprimé sur l'emballage ou près de la date de consommation
               optionnal: true
             - label: Date limite (si possible)
-              rank: 5
               type: DATE
               optionnal: true
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 6
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo du produit
@@ -153,47 +140,37 @@
           example: 'Exemple : pizza dans une boulangerie, plat dans un restaurant...'
           detailInputs:
             - label: Nom du produit
-              rank: 1
               type: TEXT
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 2
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
             - label: Quel est le problème ?
-              rank: 3
               type: TEXT
           fileLabel: Photo du produit
         - title: Un produit vendu dans un emballage
           example: "Exemple : bouteille d'eau, conserve de légumes, paquet de chips..."
           detailInputs:
             - label: "C'est un produit vendu&#160;:"
-              rank: 1
               type: RADIO
               options:
                 - au rayon frais
                 - au rayon surgelé
                 - à température ambiante
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Marque
-              rank: 3
               type: TEXT
             - label: Numéro de lot (si possible)
-              rank: 4
               type: TEXT
               placeholder: il est imprimé sur l'emballage ou près de la date de consommation
               optionnal: true
             - label: Date limite (si possible)
-              rank: 5
               type: DATE
               optionnal: true
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 6
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
             - label: Quel est le problème ?
-              rank: 7
               type: TEXT
           fileLabel: Photo du produit
     - title: Corps étranger "mou"
@@ -207,10 +184,8 @@
           example: 'Exemple : pizza dans une boulangerie, plat dans un restaurant'
           detailInputs:
             - label: Nom du produit
-              rank: 1
               type: TEXT
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 2
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo du produit
@@ -218,29 +193,23 @@
           example: "Exemple : bouteille d'eau, conserve de légumes, paquet de chips"
           detailInputs:
             - label: "C'est un produit vendu&#160;:"
-              rank: 1
               type: RADIO
               options:
                 - au rayon frais
                 - au rayon surgelé
                 - à température ambiante
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Marque
-              rank: 3
               type: TEXT
             - label: Numéro de lot (si possible)
-              rank: 4
               type: TEXT
               placeholder: il est imprimé sur l'emballage ou près de la date de consommation
               optionnal: true
             - label: Date limite (si possible)
-              rank: 5
               type: DATE
               optionnal: true
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 6
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo du produit
@@ -268,10 +237,8 @@
           example: 'Exemple : pizza dans une boulangerie, plat dans un restaurant'
           detailInputs:
             - label: Nom du produit
-              rank: 1
               type: TEXT
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 2
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo du produit
@@ -279,28 +246,22 @@
           example: "Exemple : bouteille d'eau, conserve de légumes, paquet de chips"
           detailInputs:
             - label: "C'est un produit vendu&#160;:"
-              rank: 1
               type: RADIO
               options:
                 - au rayon frais
                 - au rayon surgelé
                 - à température ambiante
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Marque
-              rank: 3
               type: TEXT
             - label: Numéro de lot (si possible)
-              rank: 4
               type: TEXT
               optionnal: true
             - label: Date limite (si possible)
-              rank: 5
               type: DATE
               optionnal: true
             - label: Date du constat (ou d'achat suivant le cas)
-              rank: 6
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
           fileLabel: Photo du produit
@@ -316,7 +277,6 @@
         - '274'
       detailInputs:
         - label: Quelle information manque-t-il&#160;?
-          rank: 1
           type: RADIO
           options:
             - Date limite
@@ -325,17 +285,13 @@
             - Pas d'étiquette du tout
             - Autre (à préciser)
         - label: Date du constat (ou d'achat suivant le cas)
-          rank: 2
           type: DATE_NOT_IN_FUTURE
           defaultValue: SYSDATE
         - label: Type de produit
-          rank: 3
           type: TEXT
         - label: Nom /marque
-          rank: 4
           type: TEXT
         - label: Qu'avez-vous constaté&#160;?
-          rank: 5
           type: TEXTAREA
       fileLabel: Photos du produit
     - title: Informations trompeuses ou fausses
@@ -345,22 +301,18 @@
         - '271'
       detailInputs:
         - label: Date du constat (ou d'achat suivant le cas)
-          rank: 1
           type: DATE_NOT_IN_FUTURE
           defaultValue: SYSDATE
         - label: De quel produit s'agit-il&#160;?
-          rank: 2
           type: RADIO
           options:
             - Alcool (vin, spiritueux...)
             - Fruits et légumes
             - Autre (à préciser)
         - label: Nom  et marque du produit
-          rank: 3
           type: TEXT
           optionnal: true
         - label: À propos de quoi est-ce trompeur&#160;?
-          rank: 4
           type: RADIO
           options:
             - L'origine
@@ -370,7 +322,6 @@
             - Une marque
             - Autres (à préciser)
         - label: Pourquoi trouvez-vous ça trompeur&#160;?
-          rank: 5
           type: TEXTAREA
           optionnal: true
       fileLabel: Photos du produit (si possible de tous les côtés de l'emballage)
@@ -381,17 +332,13 @@
         - '211'
       detailInputs:
         - label: Date du constat (ou d'achat suivant le cas)
-          rank: 1
           type: DATE_NOT_IN_FUTURE
           defaultValue: SYSDATE
         - label: Type de produit
-          rank: 2
           type: TEXT
         - label: Nom /marque
-          rank: 3
           type: TEXT
         - label: Qu'avez-vous constaté&#160;?
-          rank: 4
           type: TEXTAREA
     - title: Autres problèmes d'étiquette ou emballage
       reponseconsoCode:
@@ -410,7 +357,6 @@
       example: Tarer une balance signifie imposer la valeur zéro sur une balance alors qu'il y a un emballage dessus, pour ne peser que le contenu.
       detailInputs:
         - label: Préciser le lieu (rayon) dans le cas d'un grand magasin
-          rank: 1
           type: TEXT
           placeholder: lieu
           optionnal: true
@@ -421,50 +367,39 @@
           example: "La quantité est directement imprimée sur l'emballage par le fabricant"
           detailInputs:
             - label: La lettre "e" est-elle écrite à côté de l'indication du poids/volume&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Oui
                 - Non
             - label: Type de produit
-              rank: 2
               type: TEXT
             - label: Nom /marque
-              rank: 3
               type: TEXT
             - label: Quelle erreur a été constatée&#160;?
-              rank: 4
               type: TEXTAREA
         - title: Un produit emballé et étiqueté par le magasin comme une barquette de viande
           example: 'La quantité est marquée sur une étiquette collée par le commerçant'
           detailInputs:
             - label: Date du constat ou d'achat
-              rank: 1
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Elements d'identification (date limite, n° de lot)
-              rank: 3
               type: TEXT
               optionnal: true
               placeholder: Elements d'identification
             - label: Description
-              rank: 4
               type: TEXTAREA
         - title: Un produit sans emballage, directement consommé
           example: 'Exemple : verre de vin dans un café, plat au restaurant'
           detailInputs:
             - label: Date du constat ou d'achat
-              rank: 1
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
             - label: Nom du produit
-              rank: 2
               type: TEXT
             - label: Description
-              rank: 3
               type: TEXTAREA
     - title: Autre
 - title: Produit pas bon
@@ -487,20 +422,15 @@
     - '331'
   detailInputs:
     - label: Date du constat
-      rank: 1
       type: DATE_NOT_IN_FUTURE
       defaultValue: SYSDATE
     - label: Heure du constat
-      rank: 2
       type: TIMESLOT
       optionnal: true
     - label: Nom du produit / marque
-      rank: 3
       type: TEXT
     - label: Numéro de lot / référence
-      rank: 4
       type: TEXT
     - label: Qu'avez-vous constaté&#160;?
-      rank: 5
       type: TEXTAREA
 - title: Autre problème de nourriture

--- a/src/anomaly/yml/common/nourriture.yml
+++ b/src/anomaly/yml/common/nourriture.yml
@@ -122,10 +122,10 @@
             - label: Numéro de lot (si possible)
               type: TEXT
               placeholder: Il est imprimé sur l'emballage ou près de la date de consommation
-              optionnal: true
+              optional: true
             - label: Date limite (si possible)
               type: DATE
-              optionnal: true
+              optional: true
             - label: Date du constat (ou d'achat suivant le cas)
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
@@ -163,10 +163,10 @@
             - label: Numéro de lot (si possible)
               type: TEXT
               placeholder: il est imprimé sur l'emballage ou près de la date de consommation
-              optionnal: true
+              optional: true
             - label: Date limite (si possible)
               type: DATE
-              optionnal: true
+              optional: true
             - label: Date du constat (ou d'achat suivant le cas)
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
@@ -205,10 +205,10 @@
             - label: Numéro de lot (si possible)
               type: TEXT
               placeholder: il est imprimé sur l'emballage ou près de la date de consommation
-              optionnal: true
+              optional: true
             - label: Date limite (si possible)
               type: DATE
-              optionnal: true
+              optional: true
             - label: Date du constat (ou d'achat suivant le cas)
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
@@ -257,10 +257,10 @@
               type: TEXT
             - label: Numéro de lot (si possible)
               type: TEXT
-              optionnal: true
+              optional: true
             - label: Date limite (si possible)
               type: DATE
-              optionnal: true
+              optional: true
             - label: Date du constat (ou d'achat suivant le cas)
               type: DATE_NOT_IN_FUTURE
               defaultValue: SYSDATE
@@ -311,7 +311,7 @@
             - Autre (à préciser)
         - label: Nom  et marque du produit
           type: TEXT
-          optionnal: true
+          optional: true
         - label: À propos de quoi est-ce trompeur&#160;?
           type: RADIO
           options:
@@ -323,7 +323,7 @@
             - Autres (à préciser)
         - label: Pourquoi trouvez-vous ça trompeur&#160;?
           type: TEXTAREA
-          optionnal: true
+          optional: true
       fileLabel: Photos du produit (si possible de tous les côtés de l'emballage)
     - title: Informations sur l'emballage uniquement en langue étrangère
       example: Aucune information traduite en français
@@ -359,7 +359,7 @@
         - label: Préciser le lieu (rayon) dans le cas d'un grand magasin
           type: TEXT
           placeholder: lieu
-          optionnal: true
+          optional: true
     - title: La quantité annoncée est non conforme
       subcategoriesTitle: Quel est le type de produit&#160;?
       subcategories:
@@ -387,7 +387,7 @@
               type: TEXT
             - label: Elements d'identification (date limite, n° de lot)
               type: TEXT
-              optionnal: true
+              optional: true
               placeholder: Elements d'identification
             - label: Description
               type: TEXTAREA
@@ -426,7 +426,7 @@
       defaultValue: SYSDATE
     - label: Heure du constat
       type: TIMESLOT
-      optionnal: true
+      optional: true
     - label: Nom du produit / marque
       type: TEXT
     - label: Numéro de lot / référence

--- a/src/anomaly/yml/common/objet.yml
+++ b/src/anomaly/yml/common/objet.yml
@@ -10,7 +10,6 @@
         - '333'
       detailInputs:
         - label: Quel est-le problème&#160;?
-          rank: 1
           type: RADIO
           options:
             - Composition
@@ -18,7 +17,6 @@
             - Disponibilité des pièces de rechange
             - Autre (à préciser)
         - label: Quel est le type de produit&#160;?
-          rank: 2
           type: RADIO
           options:
             - Textiles
@@ -28,14 +26,11 @@
             - Électroniques
             - Autre (à préciser)
         - label: Date du constat ou d'achat
-          rank: 3
           type: DATE
           defaultValue: SYSDATE
         - label: Nom / marque
-          rank: 4
           type: TEXT
         - label: Qu'avez-vous constaté&#160;?
-          rank: 5
           type: TEXTAREA
       fileLabel: Photos du code barre / n° de lot / référence
     - title: Informations du produit ou notice uniquement en langue étrangère
@@ -49,17 +44,13 @@
             - '211'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Nom / marque / type de produit
-              rank: 2
               type: TEXT
             - label: Référence
-              rank: 3
               type: TEXT
             - label: Description
-              rank: 4
               type: TEXTAREA
         - title: À l'étranger
           information:
@@ -73,7 +64,6 @@
         - ReponseConso
       detailInputs:
         - label: Quel est le type de produit&#160;?
-          rank: 1
           type: RADIO
           options:
             - Textiles
@@ -83,33 +73,25 @@
             - Électroniques
             - Autre (à préciser)
         - label: Date du constat
-          rank: 2
           type: DATE
           defaultValue: SYSDATE
         - label: Nom / marque / référence
-          rank: 3
           type: TEXT
         - label: Description
-          rank: 4
           type: TEXTAREA
 - title: Durée de vie trop courte
   example: Vous trouvez que la durée de vie de votre appareil est trop courte
   detailInputs:
     - label: Date d'achat
-      rank: 1
       type: DATE
     - label: Date du constat
-      rank: 2
       type: DATE
       defaultValue: SYSDATE
     - label: Type de produit
-      rank: 3
       type: TEXT
     - label: Nom / marque / référence
-      rank: 4
       type: TEXT
     - label: Description
-      rank: 5
       type: TEXTAREA
 - title: La quantité annoncée est non conforme
   subcategoriesTitle: Quel est le type de produit&#160;?
@@ -124,50 +106,39 @@
       example: "La quantité est directement imprimée sur l'emballage par le fabricant"
       detailInputs:
         - label: La lettre "e" est-elle écrite à côté de l'indication du poids/volume&#160;?
-          rank: 1
           type: RADIO
           options:
             - Oui
             - Non
         - label: Type de produit
-          rank: 2
           type: TEXT
         - label: Nom /marque
-          rank: 3
           type: TEXT
         - label: Quelle erreur a été constatée&#160;?
-          rank: 4
           type: TEXTAREA
     - title: Un produit emballé et étiqueté par le vendeur comme une barquette de viande
       example: 'La quantité est marquée sur une étiquette collée par le commerçant'
       detailInputs:
         - label: Date du constat ou d'achat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Nom du produit
-          rank: 2
           type: TEXT
         - label: Elements d'identification (date limite, n° de lot)
-          rank: 3
           type: TEXT
           optionnal: true
           placeholder: Elements d'identification
         - label: Description
-          rank: 4
           type: TEXTAREA
     - title: Un produit sans emballage, directement consommé
       example: 'Exemple : verre de vin dans un café, plat au restaurant'
       detailInputs:
         - label: Date du constat ou d'achat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Nom du produit
-          rank: 2
           type: TEXT
         - label: Description
-          rank: 3
           type: TEXTAREA
 - title: Produit en retrait / rappel
   example: Le produit vendu fait l'objet d'une mesure de retrait / rappel des autorités
@@ -176,19 +147,14 @@
     - '331'
   detailInputs:
     - label: Date du constat
-      rank: 1
       type: DATE
       defaultValue: SYSDATE
     - label: Heure du constat
-      rank: 2
       type: TIMESLOT
       optionnal: true
     - label: Nom du produit / marque
-      rank: 3
       type: TEXT
     - label: N° de lot / référence
-      rank: 4
       type: TEXT
     - label: Qu'avez-vous constaté&#160;?
-      rank: 5
       type: TEXTAREA

--- a/src/anomaly/yml/common/objet.yml
+++ b/src/anomaly/yml/common/objet.yml
@@ -126,7 +126,7 @@
           type: TEXT
         - label: Elements d'identification (date limite, n° de lot)
           type: TEXT
-          optionnal: true
+          optional: true
           placeholder: Elements d'identification
         - label: Description
           type: TEXTAREA
@@ -151,7 +151,7 @@
       defaultValue: SYSDATE
     - label: Heure du constat
       type: TIMESLOT
-      optionnal: true
+      optional: true
     - label: Nom du produit / marque
       type: TEXT
     - label: N° de lot / référence

--- a/src/anomaly/yml/subcategories/achat-magasin.yml
+++ b/src/anomaly/yml/subcategories/achat-magasin.yml
@@ -31,7 +31,6 @@
               type: DATE
               defaultValue: SYSDATE
             - label: Description
-              example: Précisez si possible le rayon concerné
               type: TEXTAREA
         - title: Les prix sont plus élevés qu'ailleurs
           information:
@@ -67,7 +66,6 @@
               type: DATE
               defaultValue: SYSDATE
             - label: Description
-              example: Précisez si possible le problème
               type: TEXTAREA
     - title: Une commande effectuée
       example: 'Exemple : commande jamais livrée, produit non conforme'
@@ -198,7 +196,6 @@
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Description
-                  example: Précisez si possible le rayon concerné
                   type: TEXTAREA
             - title: Les prix sont plus élevés qu'ailleurs
               information:
@@ -232,7 +229,6 @@
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Description
-                  example: Précisez si possible le problème
                   type: TEXTAREA
         - title: Hygiène
           tags:

--- a/src/anomaly/yml/subcategories/achat-magasin.yml
+++ b/src/anomaly/yml/subcategories/achat-magasin.yml
@@ -157,14 +157,14 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
                 - label: Quel produit&#160;?
                   type: TEXT
                   placeholder: Nom ou type de produit
                 - label: Quel était le prix indiqué si vous vous en rappelez&#160;?
                   type: TEXT
                   placeholder: Prix indiqué
-                  optionnal: true
+                  optional: true
                 - label: "L'avez-vous signalé au moment de payer&#160;?"
                   type: RADIO
                   options:
@@ -175,7 +175,7 @@
                   options:
                     - Oui
                     - Non
-                  optionnal: true
+                  optional: true
                 - label: Description
                   type: TEXTAREA
             - title: Il manque des prix / les prix sont illisibles
@@ -268,13 +268,13 @@
                 - label: Pour corriger ce problème, dites-nous en plus
                   type: TEXTAREA
                   placeholder: 'rayon du magasin, type de saleté'
-                  optionnal: true
+                  optional: true
                 - label: Date du constat
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Hygiène du personnel
               example: 'Exemple : tenue sale ou inadaptée'
               ccrfCode:
@@ -326,13 +326,13 @@
                         - Autre (à préciser)
                     - label: Pour corriger ce problème, dites-nous en plus
                       type: TEXTAREA
-                      optionnal: true
+                      optional: true
                     - label: Date du constat
                       type: DATE
                       defaultValue: SYSDATE
                     - label: Heure du constat (facultatif)
                       type: TIMESLOT
-                      optionnal: true
+                      optional: true
             - title: Problème de température
               example: 'Exemple : rupture de la chaîne du froid'
               ccrfCode:
@@ -353,13 +353,13 @@
                     - Autre problème de température
                 - label: Pour corriger ce problème, dites-nous en plus
                   type: TEXTAREA
-                  optionnal: true
+                  optional: true
                 - label: Date du constat
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Je subis des nuisances à cause du magasin
               example: 'Exemple : les odeurs des poubelles arrivent dans mon appartement, les clients se garent devant chez moi'
               information: !!import/single ../common/info/voisinage.yml
@@ -450,7 +450,7 @@
                     - Oui
                     - Non
                     - Je n'ai pas demandé
-                  optionnal: true
+                  optional: true
                 - label: Précisez si possible la publicité concernée. Vous pouvez par exemple récupérer le lien de la publicité sur le site <a href="https&#58;//www.bonial.fr" target="_blank">bonial.fr</a>&#160;?
                   type: TEXT
                   placeholder: 'Lien vers la publicité'
@@ -490,7 +490,7 @@
                     - Autre (à préciser)
                 - label: Pourquoi trouvez-vous ça trompeur ?
                   type: TEXTAREA
-                  optionnal: true
+                  optional: true
                 - label: Avez-vous déjà contacté le commerçant pour ce problème&#160;?
                   type: RADIO
                   options:

--- a/src/anomaly/yml/subcategories/achat-magasin.yml
+++ b/src/anomaly/yml/subcategories/achat-magasin.yml
@@ -22,19 +22,16 @@
             - '224'
           detailInputs:
             - label: Veuillez préciser
-              rank: 1
               type: RADIO
               options:
                 - Prix pas affiché
                 - Prix illisible
                 - Autre (à préciser)
             - label: Date du constat
-              rank: 2
               type: DATE
               defaultValue: SYSDATE
             - label: Description
               example: Précisez si possible le rayon concerné
-              rank: 3
               type: TEXTAREA
         - title: Les prix sont plus élevés qu'ailleurs
           information:
@@ -60,7 +57,6 @@
             - '212'
           detailInputs:
             - label: "Il s'agit d'un problème sur:"
-              rank: 1
               type: RADIO
               options:
                 - Les soldes
@@ -68,12 +64,10 @@
                 - Une liquidation
                 - Autre (à préciser)
             - label: Date du constat
-              rank: 2
               type: DATE
               defaultValue: SYSDATE
             - label: Description
               example: Précisez si possible le problème
-              rank: 3
               type: TEXTAREA
     - title: Une commande effectuée
       example: 'Exemple : commande jamais livrée, produit non conforme'
@@ -161,37 +155,30 @@
                 - '224'
               detailInputs:
                 - label: Date du constat
-                  rank: 1
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat
-                  rank: 2
                   type: TIMESLOT
                   optionnal: true
                 - label: Quel produit&#160;?
-                  rank: 3
                   type: TEXT
                   placeholder: Nom ou type de produit
                 - label: Quel était le prix indiqué si vous vous en rappelez&#160;?
-                  rank: 4
                   type: TEXT
                   placeholder: Prix indiqué
                   optionnal: true
                 - label: "L'avez-vous signalé au moment de payer&#160;?"
-                  rank: 5
                   type: RADIO
                   options:
                     - Oui. Pouvez-vous préciser à qui&#160;? (à préciser)
                     - Non
                 - label: Si oui, le commerçant a-t-il bien voulu vous faire payer le prix affiché&#160;?
-                  rank: 6
                   type: RADIO
                   options:
                     - Oui
                     - Non
                   optionnal: true
                 - label: Description
-                  rank: 7
                   type: TEXTAREA
             - title: Il manque des prix / les prix sont illisibles
               ccrfCode:
@@ -202,19 +189,16 @@
                 - '224'
               detailInputs:
                 - label: Veuillez préciser
-                  rank: 1
                   type: RADIO
                   options:
                     - Prix pas affiché
                     - Prix illisible
                     - Autre (à préciser)
                 - label: Date du constat
-                  rank: 2
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Description
                   example: Précisez si possible le rayon concerné
-                  rank: 3
                   type: TEXTAREA
             - title: Les prix sont plus élevés qu'ailleurs
               information:
@@ -238,7 +222,6 @@
                 - '212'
               detailInputs:
                 - label: "Il s'agit d'un problème sur:"
-                  rank: 1
                   type: RADIO
                   options:
                     - Les soldes
@@ -246,12 +229,10 @@
                     - Une liquidation
                     - Autre (à préciser)
                 - label: Date du constat
-                  rank: 2
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Description
                   example: Précisez si possible le problème
-                  rank: 3
                   type: TEXTAREA
         - title: Hygiène
           tags:
@@ -267,7 +248,6 @@
                 - '321'
               detailInputs:
                 - label: Quel endroit est concerné&#160;?
-                  rank: 1
                   type: CHECKBOX
                   options:
                     - Intérieur du magasin
@@ -275,13 +255,11 @@
                     - WC
                     - Autre (à préciser)
                 - label: Quel est le problème&#160;?
-                  rank: 2
                   type: CHECKBOX
                   options:
                     - C'est sale
                     - C'est dégradé, en mauvais état
                 - label: À quel niveau&#160;?
-                  rank: 3
                   type: CHECKBOX
                   options:
                     - Sol
@@ -292,16 +270,13 @@
                     - Distributeur automatique
                     - Autre (à préciser)
                 - label: Pour corriger ce problème, dites-nous en plus
-                  rank: 4
                   type: TEXTAREA
                   placeholder: 'rayon du magasin, type de saleté'
                   optionnal: true
                 - label: Date du constat
-                  rank: 5
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 6
                   type: TIMESLOT
                   optionnal: true
             - title: Hygiène du personnel
@@ -341,7 +316,6 @@
                     - '312'
                   detailInputs:
                     - label: Quel animal avez-vous vu&#160;?
-                      rank: 1
                       type: RADIO
                       options:
                         - Insectes (cafard...)
@@ -349,22 +323,18 @@
                         - Oiseau (pigeon...)
                         - Autre (à préciser)
                     - label: Où l'avez-vous vu&#160;?
-                      rank: 2
                       type: CHECKBOX
                       options:
                         - Zone de production
                         - Intérieur d'un magasin
                         - Autre (à préciser)
                     - label: Pour corriger ce problème, dites-nous en plus
-                      rank: 3
                       type: TEXTAREA
                       optionnal: true
                     - label: Date du constat
-                      rank: 4
                       type: DATE
                       defaultValue: SYSDATE
                     - label: Heure du constat (facultatif)
-                      rank: 5
                       type: TIMESLOT
                       optionnal: true
             - title: Problème de température
@@ -379,7 +349,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Quel est le problème&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Vitrine ou réfrigérateur trop chaud, cassé ou en panne
@@ -387,15 +356,12 @@
                     - Transport à température ambiante de produits frais ou congelés
                     - Autre problème de température
                 - label: Pour corriger ce problème, dites-nous en plus
-                  rank: 2
                   type: TEXTAREA
                   optionnal: true
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Je subis des nuisances à cause du magasin
@@ -469,11 +435,9 @@
                 - '2243'
               detailInputs:
                 - label: Date du constat
-                  rank: 1
                   type: DATE
                   defaultValue: SYSDATE
                 - label: De quelle publicité s'agit-il&#160;?
-                  rank: 2
                   type: RADIO
                   options:
                     - Catalogue papier
@@ -482,11 +446,9 @@
                     - Spot télé (à préciser)
                     - Autre (à préciser)
                 - label: Quel est le produit que vous vouliez&#160;?
-                  rank: 3
                   type: TEXT
                   placeholder: Type, nom et marque du produit
                 - label: Le commerçant vous-a-t-il proposé de commander le produit ou d'en avoir un autre équivalent&#160;?
-                  rank: 4
                   type: RADIO
                   options:
                     - Oui
@@ -494,7 +456,6 @@
                     - Je n'ai pas demandé
                   optionnal: true
                 - label: Précisez si possible la publicité concernée. Vous pouvez par exemple récupérer le lien de la publicité sur le site <a href="https&#58;//www.bonial.fr" target="_blank">bonial.fr</a>&#160;?
-                  rank: 5
                   type: TEXT
                   placeholder: 'Lien vers la publicité'
               fileLabel: Photo(s) de la publicité si possible
@@ -508,11 +469,9 @@
                 - '271'
               detailInputs:
                 - label: Date du constat
-                  rank: 1
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Qu'est-ce qui est trompeur&#160;?
-                  rank: 2
                   type: RADIO
                   options:
                     - L'emballage d'un produit
@@ -525,7 +484,6 @@
                     - La façon de mettre en vente
                     - Autre (à préciser)
                 - label: À propos de quoi est-ce trompeur&#160;?
-                  rank: 3
                   type: RADIO
                   options:
                     - L'origine du produit
@@ -535,11 +493,9 @@
                     - Une marque
                     - Autre (à préciser)
                 - label: Pourquoi trouvez-vous ça trompeur ?
-                  rank: 4
                   type: TEXTAREA
                   optionnal: true
                 - label: Avez-vous déjà contacté le commerçant pour ce problème&#160;?
-                  rank: 5
                   type: RADIO
                   options:
                     - Oui
@@ -565,24 +521,19 @@
                     - title: Il y a moins de 2 ans
                       detailInputs:
                         - label: Date d'achat
-                          rank: 1
                           type: DATE
                         - label: Nom du produit
-                          rank: 2
                           type: TEXT
                         - label: Date du constat
-                          rank: 3
                           type: DATE
                           defaultValue: SYSDATE
                         - label: Interlocuteur
-                          rank: 4
                           type: RADIO
                           options:
                             - Vendeur
                             - Accueil magasin
                             - Service client (téléphone, mail, courrier)
                         - label: Pour quelle raison le commerçant ne veut-il pas vous reprendre le produit&#160;?
-                          rank: 5
                           type: TEXTAREA
                       fileLabel: Preuve d'achat / publicité / offre de vente
                     - title: Il y a plus de 2 ans
@@ -596,20 +547,15 @@
                             - title: J'ai pris connaissance des conditions écrites dans mon contrat de garantie
                               detailInputs:
                                 - label: Date d'achat
-                                  rank: 1
                                   type: DATE
                                 - label: Nom du produit
-                                  rank: 2
                                   type: TEXT
                                 - label: Date de fin de la garantie supplémentaire
-                                  rank: 3
                                   type: DATE
                                 - label: Date du constat
-                                  rank: 4
                                   type: DATE
                                   defaultValue: SYSDATE
                                 - label: Motif de refus
-                                  rank: 5
                                   type: TEXT
                               fileLabel: Contrat de garantie / publicité de l'offre de vente / document se référant à la garantie
                         - title: Non
@@ -636,24 +582,19 @@
                     - title: Il y a moins de 6 mois
                       detailInputs:
                         - label: Date d'achat
-                          rank: 1
                           type: DATE
                         - label: Nom du produit
-                          rank: 2
                           type: TEXT
                         - label: Date du constat
-                          rank: 3
                           type: DATE
                           defaultValue: SYSDATE
                         - label: Interlocuteur
-                          rank: 4
                           type: RADIO
                           options:
                             - Vendeur
                             - Accueil magasin
                             - Service client (téléphone, mail, courrier)
                         - label: Pour quelle raison le commerçant ne veut-il pas vous reprendre le produit&#160;?
-                          rank: 5
                           type: TEXTAREA
                       fileLabel: Preuve d'achat / publicité / offre de vente
                     - title: Il y a plus de 6 mois
@@ -667,20 +608,15 @@
                             - title: J'ai pris connaissance des conditions écrites dans mon contrat de garantie
                               detailInputs:
                                 - label: Date d'achat
-                                  rank: 1
                                   type: DATE
                                 - label: Nom du produit
-                                  rank: 2
                                   type: TEXT
                                 - label: Date de fin de garantie supplémentaire
-                                  rank: 3
                                   type: DATE
                                 - label: Date du constat
-                                  rank: 4
                                   type: DATE
                                   defaultValue: SYSDATE
                                 - label: Motif de refus
-                                  rank: 5
                                   type: TEXT
                               fileLabel: Contrat de garantie / publicité de l'offre de vente / document se référant à la garantie
                         - title: Non
@@ -907,20 +843,17 @@
         - ProduitAlimentaire
       detailInputs:
         - label: Que s'est-il passé ?
-          rank: 1
           type: RADIO
           options:
             - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
             - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
             - Autre (à préciser)
         - label: Avez-vous payé au moment du démarchage&#160;?
-          rank: 2
           type: RADIO
           options:
             - Oui
             - Non
         - label: Date du démarchage
-          rank: 3
           type: DATE
           defaultValue: SYSDATE
     - title: C'est un objet
@@ -929,20 +862,17 @@
         - ProduitIndustriel
       detailInputs:
         - label: Que s'est-il passé ?
-          rank: 1
           type: RADIO
           options:
             - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
             - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
             - Autre (à préciser)
         - label: Avez-vous payé au moment du démarchage&#160;?
-          rank: 2
           type: RADIO
           options:
             - Oui
             - Non
         - label: Date du démarchage
-          rank: 3
           type: DATE
           defaultValue: SYSDATE
     - title: C'est un produit dangereux

--- a/src/anomaly/yml/subcategories/banque-assurance-mutuelle.yml
+++ b/src/anomaly/yml/subcategories/banque-assurance-mutuelle.yml
@@ -31,17 +31,14 @@
             - DemarchageTelephonique
           detailInputs:
             - label: Date de l'appel
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Non
                 - Oui (à préciser)
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 3
               type: TEXTAREA
         - title: Autre
           companyKind: SIRET
@@ -83,20 +80,17 @@
             - ReponseConso
           detailInputs:
             - label: Que s'est-il passé ?
-              rank: 1
               type: RADIO
               options:
                 - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
                 - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
                 - Autre (à préciser)
             - label: Avez-vous payé au moment du démarchage&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Oui
                 - Non
             - label: Date du démarchage
-              rank: 3
               type: DATE
               defaultValue: SYSDATE
         - title: Démarchage téléphonique
@@ -109,17 +103,14 @@
             - ReponseConso
           detailInputs:
             - label: Date de l'appel
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Non
                 - Oui (à préciser)
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 3
               type: TEXTAREA
         - title: Autre
           reponseconsoCode:

--- a/src/anomaly/yml/subcategories/cafe-restaurant.yml
+++ b/src/anomaly/yml/subcategories/cafe-restaurant.yml
@@ -32,7 +32,7 @@
             - Autre (à préciser)
         - label: Vous pouvez préciser le problème en quelques mots
           type: TEXT
-          optionnal: true
+          optional: true
     - title: Hygiène des locaux et du matériel
       example: 'Exemple : cuisine sale, odeur de poubelle dans ma cour'
       reponseconsoCode:
@@ -46,7 +46,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
             - label: Quel endroit est concerné&#160;?
               type: CHECKBOX
               options:
@@ -120,7 +120,7 @@
           defaultValue: SYSDATE
         - label: Heure du constat (facultatif)
           type: TIMESLOT
-          optionnal: true
+          optional: true
         - label: Quel est le problème&#160;?
           type: RADIO
           options:
@@ -130,7 +130,7 @@
             - Autre problème de température (à préciser)
         - label: Pouvez-vous préciser ?
           type: TEXT
-          optionnal: true
+          optional: true
       fileLabel: Si possible, merci de joindre une photo ou un document pour appuyer votre signalement.
 - title: Prix et paiement
   companyKind: SIRET

--- a/src/anomaly/yml/subcategories/cafe-restaurant.yml
+++ b/src/anomaly/yml/subcategories/cafe-restaurant.yml
@@ -14,11 +14,9 @@
         - '312'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel animal avez-vous vu&#160;?
-          rank: 2
           type: RADIO
           options:
             - Insectes (cafard...)
@@ -26,7 +24,6 @@
             - Oiseau (pigeon...)
             - Autre (à préciser)
         - label: Où l'avez-vous vu&#160;?
-          rank: 3
           type: CHECKBOX
           options:
             - Cuisine ou zone de production
@@ -34,7 +31,6 @@
             - Dans mon plat
             - Autre (à préciser)
         - label: Vous pouvez préciser le problème en quelques mots
-          rank: 4
           type: TEXT
           optionnal: true
     - title: Hygiène des locaux et du matériel
@@ -46,15 +42,12 @@
           example: 'Exemple : cuisine sale, WC sale'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 2
               type: TIMESLOT
               optionnal: true
             - label: Quel endroit est concerné&#160;?
-              rank: 3
               type: CHECKBOX
               options:
                 - La cuisine et zone de production / stockage
@@ -63,13 +56,11 @@
                 - Les WC
                 - Autre (à préciser)
             - label: Quel est le problème&#160;?
-              rank: 4
               type: CHECKBOX
               options:
                 - C'est sale
                 - C'est dégradé, en mauvais état
             - label: À quel niveau&#160;?
-              rank: 5
               type: CHECKBOX
               options:
                 - Sol / mur
@@ -100,29 +91,23 @@
               example: 'Exemple : pas de tenue spécifique, torse-nu en cuisine'
               detailInputs:
                 - label: Date de constat
-                  rank: 1
                   type: DATE
                 - label: Quel est le problème ?
-                  rank: 2
                   type: TEXT
               fileLabel: Merci de joindre si possible tout document (photo) pour appuyer votre signalement.
         - title: La tenue de travail est sale
           detailInputs:
             - label: Date de constat
-              rank: 1
               type: DATE
             - label: Quel est le problème ?
-              rank: 2
               type: TEXT
           fileLabel: Merci de joindre si possible tout document (photo) pour appuyer votre signalement.
         - title: Mauvaises pratiques d'hygiène
           example: 'Exemple : personne qui fume en cuisine'
           detailInputs:
             - label: Date de constat
-              rank: 1
               type: DATE
             - label: Quel est le problème ?
-              rank: 2
               type: TEXT
           fileLabel: Merci de joindre si possible tout document (photo) pour appuyer votre signalement.
     - title: Problème de température
@@ -131,15 +116,12 @@
         - '322'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Heure du constat (facultatif)
-          rank: 2
           type: TIMESLOT
           optionnal: true
         - label: Quel est le problème&#160;?
-          rank: 3
           type: RADIO
           options:
             - Vitrine / réfrigérateur trop chaud ou en panne
@@ -147,7 +129,6 @@
             - Transport à température ambiante de produits frais ou congelés
             - Autre problème de température (à préciser)
         - label: Pouvez-vous préciser ?
-          rank: 3
           type: TEXT
           optionnal: true
       fileLabel: Si possible, merci de joindre une photo ou un document pour appuyer votre signalement.
@@ -163,12 +144,10 @@
       example: 'Exemple : absence de prix sur la carte des vins'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Description
           example: Pouvez-vous nous en dire plus ?
-          rank: 2
           type: TEXTAREA
           placeholder: "absence de carte des vins, absence des prix à l'extérieur du restaurant"
       fileLabel: Merci de joindre si possible des éléments pour appuyer votre signalement (photo du menu, photo de la vitrine...)
@@ -179,22 +158,17 @@
         - LitigeContractuel
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
         - label: Quel était le prix affiché ?
-          rank: 2
           type: TEXT
         - label: Combien avez-vous payé ?
-          rank: 3
           type: TEXT
         - label: L'avez-vous signalé au gérant / serveur ?
-          rank: 4
           type: RADIO
           options:
             - Oui
             - Non
         - label: Si oui, vous a-t-il donné une raison ?
-          rank: 5
           type: RADIO
           options:
             - Les prix affichés ne sont pas à jour
@@ -275,10 +249,8 @@
         - ReponseConso
       detailInputs:
         - label: Date de constat
-          rank: 1
           type: DATE
         - label: Quel est le problème ?
-          rank: 2
           type: RADIO
           options:
             - Refus de me faire une note
@@ -299,15 +271,12 @@
         - '271'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel type de produit était indisponible&#160;?
-          rank: 2
           type: TEXT
           placeholder: 'Exemple : Vin blanc, menu en promotion '
         - label: Le commerçant vous a-t-il donné une raison ?
-          rank: 3
           type: RADIO
           options:
             - Non
@@ -319,11 +288,9 @@
         - '271'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Qu'est-ce qui est trompeur&#160;?
-          rank: 2
           type: RADIO
           options:
             - La carte, le menu, une pancarte
@@ -331,7 +298,6 @@
             - Le discours d'un serveur ou du gérant
             - Autre (à préciser)
         - label: À propos de quoi est-ce trompeur&#160;?
-          rank: 3
           type: RADIO
           options:
             - "L'origine (exemple : origine des vins )"
@@ -339,11 +305,9 @@
             - 'Une marque (exemple : la marque de rhum proposée est mensongère)'
             - Autre (à préciser)
         - label: Précisez en quelques mots pourquoi vous trouvez cela trompeur
-          rank: 4
           type: TEXT
           placeholder: Soyez factuel et courtois, merci !
         - label: Avez-vous déjà expliqué le problème au commerçant &#160;?
-          rank: 5
           type: RADIO
           options:
             - Oui
@@ -365,11 +329,9 @@
         - '521'
       detailInputs:
         - label: Date du problème
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Pour quelle raison a-t-on refusé de vous servir ou de vous donner une table ?
-          rank: 2
           type: TEXTAREA
       fileLabel: Vous pouvez joindre des éléments pour appuyer votre signalement.
     - title: Mon chien a été refusé
@@ -382,10 +344,8 @@
             - '521'
           detailInputs:
             - label: Date du refus
-              rank: 1
               type: DATE
             - label: Pouvez-vous nous décrire ce qu'il s'est passé ?
-              rank: 2
               type: TEXTAREA
           fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
 - title: Qualité des plats/boissons
@@ -400,11 +360,9 @@
         - '271'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: À propos de quoi est-ce trompeur selon vous&#160;?
-          rank: 2
           type: RADIO
           options:
             - "L'origine (exemple : origine des vins)"
@@ -412,11 +370,9 @@
             - 'Une marque (exemple: la marque de rhum proposée est mensongère'
             - Autre (à préciser)
         - label: Précisez en quelques mots pourquoi vous trouvez cela trompeur
-          rank: 3
           type: TEXT
           placeholder: Soyez factuel et courtois, merci !
         - label: Avez-vous déjà expliqué le problème au commerçant &#160;?
-          rank: 4
           type: RADIO
           options:
             - Oui
@@ -433,13 +389,10 @@
         - '321'
       detailInputs:
         - label: Date de constat
-          rank: 1
           type: DATE
         - label: Quel produit est concerné ?
-          rank: 2
           type: TEXT
         - label: Quel est le problème ?
-          rank: 3
           type: RADIO
           options:
             - Produit pas frais

--- a/src/anomaly/yml/subcategories/cafe-restaurant.yml
+++ b/src/anomaly/yml/subcategories/cafe-restaurant.yml
@@ -147,7 +147,6 @@
           type: DATE
           defaultValue: SYSDATE
         - label: Description
-          example: Pouvez-vous nous en dire plus ?
           type: TEXTAREA
           placeholder: "absence de carte des vins, absence des prix à l'extérieur du restaurant"
       fileLabel: Merci de joindre si possible des éléments pour appuyer votre signalement (photo du menu, photo de la vitrine...)

--- a/src/anomaly/yml/subcategories/coronavirus.yml
+++ b/src/anomaly/yml/subcategories/coronavirus.yml
@@ -12,12 +12,12 @@
 #        - label : Volume du produit et autres caractéristiques
 #          rank: 2
 #          type: TEXTAREA
-#          optionnal: true
+#          optional: true
 #          placeholder: Volume, marque...
 #        - label : Quel est le prix de vente ?
 #          rank: 3
 #          type: TEXT
-#          optionnal: true
+#          optional: true
 #      fileLabel: Photo du prix et du produit si possible
 #    - title: Masque
 #    - title: Autre
@@ -78,7 +78,7 @@
           defaultValue: SYSDATE
         - label: Quel est le prix de vente ?
           type: TEXT
-          optionnal: true
+          optional: true
       fileLabel: Photo du prix et du produit si possible
     - title: Le prix de l'autotest qui est fait sous la supervision d'un pharmacien
       detailInputs:
@@ -87,5 +87,5 @@
           defaultValue: SYSDATE
         - label: Quel est le prix ?
           type: TEXT
-          optionnal: true
+          optional: true
       fileLabel: Photo de la facture ou de la note

--- a/src/anomaly/yml/subcategories/coronavirus.yml
+++ b/src/anomaly/yml/subcategories/coronavirus.yml
@@ -44,31 +44,25 @@
         - LitigeContractuel
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel est le problème avec le prix de la livraison ?
-          rank: 2
           type: TEXTAREA
     - title: Autre problème de prix
       tags:
         - ReponseConso
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel est le problème ?
-          rank: 2
           type: TEXTAREA
     - title: Problème avec un produit livré
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel est le problème ?
-          rank: 2
           type: TEXTAREA
       fileLabel: Photo du produit si possible
 - title: Le prix de l'autotest est trop élevé
@@ -80,22 +74,18 @@
     - title: Le prix de l'autotest
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel est le prix de vente ?
-          rank: 2
           type: TEXT
           optionnal: true
       fileLabel: Photo du prix et du produit si possible
     - title: Le prix de l'autotest qui est fait sous la supervision d'un pharmacien
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel est le prix ?
-          rank: 2
           type: TEXT
           optionnal: true
       fileLabel: Photo de la facture ou de la note

--- a/src/anomaly/yml/subcategories/demo.yml
+++ b/src/anomaly/yml/subcategories/demo.yml
@@ -88,7 +88,6 @@
     - label: (label) input de type TEXT, et divers champs optionnels
       type: TEXT
       placeholder: placeholder de l'input
-      example: (example) description supplementaire de l'input
       optionnal: true
     - label: (label) input de type DATE
       type: DATE

--- a/src/anomaly/yml/subcategories/demo.yml
+++ b/src/anomaly/yml/subcategories/demo.yml
@@ -88,7 +88,7 @@
     - label: (label) input de type TEXT, et divers champs optionnels
       type: TEXT
       placeholder: placeholder de l'input
-      optionnal: true
+      optional: true
     - label: (label) input de type DATE
       type: DATE
     - label: (label) input de type DATE_NOT_IN_FUTURE

--- a/src/anomaly/yml/subcategories/demo.yml
+++ b/src/anomaly/yml/subcategories/demo.yml
@@ -81,38 +81,80 @@
           - question: Première "action", champ "question"
             answer: Première "action", champ "answer"
 - title: Sous category pour tester les "detailInputs"
-  example: Sous cat avec divers detailInputs
+  example:
+    Sous cat avec toutes les variantes possibles de detailInputs
+    (TEXT, DATE, etc.)
   detailInputs:
-    - label: (label) input de type TEXT
+    - label: simple input texte (le type TEXT)
       type: TEXT
-    - label: (label) input de type TEXT, optionnel, avec placeholder
+    - label: input texte optionnel
       type: TEXT
-      placeholder: placeholder de l'input text
       optional: true
-    - label: (label) input de type TEXTAREA
+    - label: input texte avec placeholder
       type: TEXT
-    - label: (label) input de type TEXTAREA avec placeholder
-      type: TEXT
-      placeholder: placeholder de la textarea
-    - label: (label) input de type DATE
+      placeholder: ceci est le placeholder de l'input texte
+    
+    - label: simple input de zone de texte (TEXTAREA)
+      type: TEXTAREA
+    - label: zone de texte optionnelle
+      type: TEXTAREA
+      optional: true
+    - label: zone de texte avec placeholder
+      type: TEXTAREA
+      placeholder: ceci le placeholder de la zone de texte
+    
+    
+    - label: simple input date (DATE)
       type: DATE
-    - label: (label) input de type DATE avec valeur par defaut à la date courante
+    - label: input date optionnel
+      type: DATE
+      optional: true
+    - label: input date avec la date courante comme valeur par défaut
       type: DATE
       defaultValue: SYSDATE
-    - label: (label) input de type DATE_NOT_IN_FUTURE
+    - label: input date avec la date courante comme valeur par défaut, et qui est optionnel
+      type: DATE
+      optional: true
+      defaultValue: SYSDATE
+      
+    - label: input de type date mais qui bloque les dates futures (DATE_NOT_IN_FUTURE)
       type: DATE_NOT_IN_FUTURE
+    - label: input de type date non future, avec la date courante comme valeur par défaut
+      type: DATE_NOT_IN_FUTURE
+      defaultValue: SYSDATE 
     
-    - label: (label) input de type RADIO
+    - label: input radio
       type: RADIO
       options:
-        - option A
-        - option B
-        - option C
-    - label: (label) input de type CHECKBOX
+        - première option
+        - seconde option
+        - troisième option qu'il faut préciser (à préciser)
+        - quatrième option
+    - label: input radio optionnel
+      type: RADIO
+      options:
+        - première option
+        - seconde option
+      optional: true
+
+    - label: input checkbox
+
       type: CHECKBOX
       options:
-        - option A
-        - option B
-        - option C
-    - label: (label) input de type TIMESLOT
+        - première option
+        - seconde option
+        - troisième option qu'il faut préciser (à préciser)
+        - quatrième option
+        - cinquième option qu'il faut aussi préciser (à préciser)
+    - label: input checkbox optionnel
+      type: CHECKBOX
+      options:
+        - première option
+        - seconde option
+      optional: true
+
+    - label: input timeslot
       type: TIMESLOT
+    - label: input timeslot optionnel
+      type: TIMESLOT
+      optional: true

--- a/src/anomaly/yml/subcategories/demo.yml
+++ b/src/anomaly/yml/subcategories/demo.yml
@@ -85,19 +85,34 @@
   detailInputs:
     - label: (label) input de type TEXT
       type: TEXT
-    - label: (label) input de type TEXT, et divers champs optionnels
+    - label: (label) input de type TEXT, optionnel, avec placeholder
       type: TEXT
-      placeholder: placeholder de l'input
+      placeholder: placeholder de l'input text
       optional: true
+    - label: (label) input de type TEXTAREA
+      type: TEXT
+    - label: (label) input de type TEXTAREA avec placeholder
+      type: TEXT
+      placeholder: placeholder de la textarea
     - label: (label) input de type DATE
       type: DATE
+    - label: (label) input de type DATE avec valeur par defaut à la date courante
+      type: DATE
+      defaultValue: SYSDATE
     - label: (label) input de type DATE_NOT_IN_FUTURE
       type: DATE_NOT_IN_FUTURE
-    - label: (label) input de type TIMESLOT
-      type: TIMESLOT
+    
     - label: (label) input de type RADIO
       type: RADIO
+      options:
+        - option A
+        - option B
+        - option C
     - label: (label) input de type CHECKBOX
       type: CHECKBOX
-    - label: (label) input de type TEXTAREA
-      type: TEXTAREA
+      options:
+        - option A
+        - option B
+        - option C
+    - label: (label) input de type TIMESLOT
+      type: TIMESLOT

--- a/src/anomaly/yml/subcategories/eau-gaz-electricite.yml
+++ b/src/anomaly/yml/subcategories/eau-gaz-electricite.yml
@@ -18,11 +18,9 @@
                 - ReponseConso
               detailInputs:
                 - label: Date du contrat
-                  rank: 1
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Décrivez nous plus en détails ce qui s'est passé
-                  rank: 2
                   type: TEXTAREA
               fileLabel: Joindre une copie du contrat ou tout document commercial relatif à cette avance.
         - title: Je ne suis pas d'accord avec la consommation indiquée sur ma facture
@@ -38,11 +36,9 @@
             - LitigeContractuel
           detailInputs:
             - label: Date du constat (ou du contrat)
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Quelle partie du contrat / règlement trouvez-vous abusive ?
-              rank: 2
               type: TEXTAREA
           fileLabel: Joindre une copie du contrat / règlement.
         - title: Autre
@@ -56,11 +52,9 @@
         - LitigeContractuel
       detailInputs:
         - label: Date du contrat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Date de la coupure
-          rank: 2
           type: DATE
       fileLabel: Joindre une copie du contrat / règlement.
     - title: Dégâts / travaux sur les canalisations
@@ -79,33 +73,27 @@
           example: 'Fissure, usure'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 2
               type: TEXTAREA
         - title: Le bureau d'étude impose une marque / modèle en particulier
           tags:
             - ReponseConso
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 2
               type: TEXTAREA
         - title: Autre
           tags:
             - ReponseConso
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 2
               type: TEXTAREA
 - title: Gaz / Electricité
   tags:
@@ -119,11 +107,9 @@
         - ReponseConso
       detailInputs:
         - label: Date du passage du vendeur
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Que s'est-il passé&#160;?
-          rank: 2
           type: CHECKBOX
           options:
             - le vendeur s'est fait passer pour une autre entreprise (à préciser)
@@ -132,18 +118,15 @@
             - le vendeur a demandé à voir mes factures, mon compteur
             - autre (à préciser)
         - label: Avez-vous signé, volontairement ou non, un contrat&#160;?
-          rank: 3
           type: RADIO
           options:
             - oui
             - non
         - label: Date de début du contrat s'il démarre un autre jour que celui du démarchage&#160;?
-          rank: 4
           type: DATE
           defaultValue: SYSDATE
           optionnal: true
         - label: Décrivez nous plus en détails ce qui s'est passé
-          rank: 5
           type: TEXTAREA
       fileLabel: Si possible, joindre une copie du contrat ou tout document commercial
     - title: Démarchage téléphonique
@@ -153,17 +136,14 @@
         - ReponseConso
       detailInputs:
         - label: Date de l'appel
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-          rank: 2
           type: RADIO
           options:
             - Non
             - Oui (à préciser)
         - label: Décrivez nous plus en détails ce qui s'est passé
-          rank: 3
           type: TEXTAREA
     - title: Publicité mensongère ou trompeuse
       example: 'Exemple : publicité "offre verte" mensongère'
@@ -173,11 +153,9 @@
         - '210'
       detailInputs:
         - label: Date du constat
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Quel support trouvez-vous trompeur&#160;?
-          rank: 2
           type: RADIO
           options:
             - Une publicité (affiche, flyers)
@@ -186,7 +164,6 @@
             - Le discours d'un vendeur
             - Autre (à préciser)
         - label: À propos de quoi est-ce trompeur&#160;?
-          rank: 3
           type: RADIO
           options:
             - Un label / certificat
@@ -194,11 +171,9 @@
             - 'Une information (exemple : origine géographique de mon électricité)'
             - Autre (à préciser)
         - label: Pourquoi trouvez-vous ça trompeur ?
-          rank: 4
           type: TEXTAREA
           optionnal: true
         - label: Avez-vous déjà contacté l'entreprise pour lui signaler ce problème&#160;?
-          rank: 5
           type: RADIO
           options:
             - Oui
@@ -227,15 +202,12 @@
                     - title: Oui
                       detailInputs:
                         - label: Date de signature du contrat (elle est indiquée sur votre contrat).
-                          rank: 1
                           type: DATE
                           defaultValue: SYSDATE
                         - label: Date de la demande d'annulation
-                          rank: 2
                           type: DATE
                           defaultValue: SYSDATE
                         - label: Précisez comment et à qui vous avez fait la demande
-                          rank: 3
                           type: TEXTAREA
                     - title: Non
                       information:
@@ -251,15 +223,12 @@
                         - title: Oui
                           detailInputs:
                             - label: Date de signature du contrat (elle est indiquée sur votre contrat).
-                              rank: 1
                               type: DATE
                               defaultValue: SYSDATE
                             - label: Date de la demande d'annulation
-                              rank: 2
                               type: DATE
                               defaultValue: SYSDATE
                             - label: Précisez comment et à qui vous avez fait la demande
-                              rank: 3
                               type: TEXTAREA
                         - title: Non
                           information:
@@ -285,11 +254,9 @@
             - '214'
           detailInputs:
             - label: Date du constat (ou du contrat)
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Quelle partie du contrat / règlement trouvez-vous abusive ?
-              rank: 2
               type: TEXTAREA
           fileLabel: Joindre une copie du contrat / règlement.
         - title: Autre

--- a/src/anomaly/yml/subcategories/eau-gaz-electricite.yml
+++ b/src/anomaly/yml/subcategories/eau-gaz-electricite.yml
@@ -125,7 +125,7 @@
         - label: Date de début du contrat s'il démarre un autre jour que celui du démarchage&#160;?
           type: DATE
           defaultValue: SYSDATE
-          optionnal: true
+          optional: true
         - label: Décrivez nous plus en détails ce qui s'est passé
           type: TEXTAREA
       fileLabel: Si possible, joindre une copie du contrat ou tout document commercial
@@ -172,7 +172,7 @@
             - Autre (à préciser)
         - label: Pourquoi trouvez-vous ça trompeur ?
           type: TEXTAREA
-          optionnal: true
+          optional: true
         - label: Avez-vous déjà contacté l'entreprise pour lui signaler ce problème&#160;?
           type: RADIO
           options:

--- a/src/anomaly/yml/subcategories/sante.yml
+++ b/src/anomaly/yml/subcategories/sante.yml
@@ -158,7 +158,7 @@
                 - conventionné secteur 1
                 - conventionné secteur 2
                 - non conventionné
-              optionnal: true
+              optional: true
         - title: Les prix sont exagérés
           information:
             title: Un professionnel de santé non conventionné peut choisir ses tarifs
@@ -248,13 +248,13 @@
               options:
                 - Oui
                 - Non
-              optionnal: true
+              optional: true
             - label: S'ils sont affichés, ces prix sont-ils exacts ?
               type: RADIO
               options:
                 - Oui
                 - Non
-              optionnal: true
+              optional: true
           fileLabel: Vous pouvez joindre une photo
         - title: Les prix sont trop chers
           example: 'Exemple : ce naturopathe est plus cher que ceux de la région'
@@ -276,7 +276,7 @@
               type: DATE
             - label: Si vous vous en rappelez, combien avez-vous payé ?
               type: TEXT
-              optionnal: true
+              optional: true
             - label: Avez-vous demandé une note ?
               type: RADIO
               options:
@@ -401,7 +401,7 @@
             - Non
         - label: Quel est le prix de ce supplément ?
           type: TEXT
-          optionnal: true
+          optional: true
         - label: L'hôpital / clinique vous a t-il justifié ce supplément ?
           type: RADIO
           options:

--- a/src/anomaly/yml/subcategories/sante.yml
+++ b/src/anomaly/yml/subcategories/sante.yml
@@ -28,13 +28,10 @@
         - '271'
       detailInputs:
         - label: Date de constat (ou date d'achat)
-          rank: 1
           type: DATE
         - label: Quel est le nom du produit ?
-          rank: 2
           type: TEXT
         - label: Pourquoi trouvez-vous la publicité trompeuse ?
-          rank: 3
           type: CHECKBOX
           options:
             - le produit ne remplit pas sa promesse
@@ -42,7 +39,6 @@
             - les labels (bio, naturel...) sont trompeurs
             - autre (à préciser)
         - label: Où avez-vous vu ces informations ?
-          rank: 4
           type: CHECKBOX
           options:
             - site internet
@@ -60,20 +56,17 @@
         - DemarchageADomicile
       detailInputs:
         - label: Que s'est-il passé ?
-          rank: 1
           type: RADIO
           options:
             - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
             - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
             - Autre (à préciser)
         - label: Avez-vous payé au moment du démarchage&#160;?
-          rank: 2
           type: RADIO
           options:
             - Oui
             - Non
         - label: Date du démarchage
-          rank: 3
           type: DATE
           defaultValue: SYSDATE
     - title: J'ai eu un problème de démarchage téléphonique
@@ -86,17 +79,14 @@
         - DemarchageTelephonique
       detailInputs:
         - label: Date de l'appel
-          rank: 1
           type: DATE
           defaultValue: SYSDATE
         - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-          rank: 2
           type: RADIO
           options:
             - Non
             - Oui (à préciser)
         - label: Décrivez nous plus en détails ce qui s'est passé
-          rank: 3
           type: TEXTAREA
     - title: Un produit de santé est de mauvaise qualité
       example: 'Exemple : béquille qui se tord, audioprothèse qui se fissure rapidement, préservatif qui se perce'
@@ -105,10 +95,8 @@
         - '464'
       detailInputs:
         - label: Date de constat (ou date d'achat)
-          rank: 1
           type: DATE
         - label: Quel est le type de produit ?
-          rank: 2
           type: RADIO
           options:
             - lunette / lentilles de contact
@@ -119,10 +107,8 @@
             - appareil de mesure (thermomètre, tensiomètre...)
             - autre (à préciser)
         - label: Quelle sa marque et sa référence / numéro de modèle ? Vous pouvez trouver ces informations sur votre facture d'achat.
-          rank: 3
           type: TEXT
         - label: 'Expliquez le problème en quelques mots :'
-          rank: 4
           type: TEXT
 - title: Professionnel de la santé et médecine douce
   example: 'Exemple : dentiste, opticien, kiné, psychiatre, médecine douce'
@@ -143,10 +129,8 @@
             - '226'
           detailInputs:
             - label: Date de constat
-              rank: 1
               type: DATE
             - label: Quel est le problème ?
-              rank: 2
               type: RADIO
               options:
                 - aucun affichage des prix
@@ -162,16 +146,13 @@
             - '226'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
             - label: Quel est le problème ? (plsuieurs réponses possibles)
-              rank: 2
               type: CHECKBOX
               options:
                 - pas d'indication au niveau de sa plaque
                 - absence d'affichage dans sa salle d'attente (ou lieu d'exercice si il n'a pas de salle d'attente)
             - label: "Si vous avez eu l'information par un autre moyen (mutuelle, recherche internet), pouvez-vous préciser s'il est :"
-              rank: 3
               type: RADIO
               options:
                 - conventionné secteur 1
@@ -197,23 +178,19 @@
                 - '226'
               detailInputs:
                 - label: Date du rendez-vous
-                  rank: 1
                   type: DATE
                 - label: Quel est le type de soin ?
-                  rank: 2
                   type: RADIO
                   options:
                     - pose d'un implant, bridge, couronne
                     - acte de chirurgie esthétique
                     - autre soin / traitement supérieur à 70 euros
                 - label: Quelle est le problème ? (plusieurs réponses possibles)
-                  rank: 3
                   type: CHECKBOX
                   options:
                     - le médecin / praticien m'a donné un prix à l'oral
                     - le médecin / praticien ne pas m'a remis de devis écrit
                 - label: Combien a coûté le soin au total (environ) ?
-                  rank: 4
                   type: TEXT
             - title: Le devis est incomplet
               reponseconsoCode:
@@ -221,13 +198,10 @@
                 - '226'
               detailInputs:
                 - label: Date du rendez-vous
-                  rank: 1
                   type: DATE
                 - label: Combien a coûté le soin au total ?
-                  rank: 2
                   type: TEXT
                 - label: Quelles informations manquent-ils sur votre devis  ? (plusieurs réponses possibles)
-                  rank: 3
                   type: CHECKBOX
                   options:
                     - description détaillée du soin envisagé et / ou des matériaux utilisés
@@ -240,13 +214,10 @@
                 - '210'
               detailInputs:
                 - label: Date de constat
-                  rank: 1
                   type: DATE
                 - label: Quel était le prix sur votre devis ?
-                  rank: 2
                   type: TEXT
                 - label: Combien avez-vous payé ?
-                  rank: 3
                   type: TEXT
         - title: La prestation est mal (ou pas) réalisée
           example: "Exemple : j'ai mal été soigné"
@@ -265,24 +236,20 @@
           example: "Les prix doivent être affichés en salle d'attente."
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Les prix sont-ils affichés en salle d'attente ?
-              rank: 2
               type: RADIO
               options:
                 - Oui
                 - Non
             - label: S'ils sont affichés, ces prix sont-ils lisibles et compréhensibles ?
-              rank: 3
               type: RADIO
               options:
                 - Oui
                 - Non
               optionnal: true
             - label: S'ils sont affichés, ces prix sont-ils exacts ?
-              rank: 4
               type: RADIO
               options:
                 - Oui
@@ -306,14 +273,11 @@
             - ReponseConso
           detailInputs:
             - label: Date de visite
-              rank: 1
               type: DATE
             - label: Si vous vous en rappelez, combien avez-vous payé ?
-              rank: 2
               type: TEXT
               optionnal: true
             - label: Avez-vous demandé une note ?
-              rank: 3
               type: RADIO
               options:
                 - Oui
@@ -326,10 +290,8 @@
             - '210'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
             - label: Que trouvez-vous trompeur ?
-              rank: 2
               type: RADIO
               options:
                 - la durée du soin
@@ -340,7 +302,6 @@
                 - des informations médicales fausses
                 - autre (à préciser)
             - label: 'Précisez en quelques mots pourquoi vous trouvez cela trompeur :'
-              rank: 3
               type: TEXT
               placeholder: Soyez factuel et courtois, merci !
           fileLabel: Merci de joindre une photo de la publicité, du dépliant, du site internet afin d'apporter des preuves et de traiter plus rapidement votre signalement.
@@ -354,17 +315,14 @@
             - DemarchageTelephonique
           detailInputs:
             - label: Date de l'appel
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Non
                 - Oui (à préciser)
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 3
               type: TEXTAREA
     - title: Il commercialise des lunettes ou des prothèses auditives (opticien, audioprothésiste)
       subcategories:
@@ -376,10 +334,8 @@
           example: 'Exemple : offre promotionnelle trompeuse sur des lunettes'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
             - label: Que trouvez-vous trompeur ?
-              rank: 2
               type: TEXTAREA
           fileLabel: Merci de joindre une photo de la publicité, du dépliant, du site internet afin d'apporter des preuves et de traiter plus rapidement votre signalement.
         - title: Je ne suis pas satisfait de la qualité de mes lunettes / prothèses
@@ -388,20 +344,16 @@
             - '464'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
             - label: De quel produit s'agit-il ?
-              rank: 2
               type: RADIO
               options:
                 - lunette
                 - lentilles de contact
                 - prothèse
             - label: Quel est la marque et le modèle ?
-              rank: 3
               type: TEXT
             - label: Quel est le problème ?
-              rank: 4
               type: TEXT
           fileLabel: Merci de joindre si possible une photo du produit ou de la facture d'achat.
         - title: Autre
@@ -425,10 +377,8 @@
         - '464'
       detailInputs:
         - label: Date de sortie (ou date de la facture)
-          rank: 1
           type: DATE
         - label: Quel est le montant de ces frais ?
-          rank: 2
           type: TEXT
       fileLabel: Merci de joindre si possible une photo de la facture ou du panneau d'affichage des prix pour appuyer votre signalement.
     - title: J'ai été facturé pour un supplément que je n'avais pas demandé
@@ -440,24 +390,19 @@
         - '210'
       detailInputs:
         - label: Date de sortie (ou date de la facture)
-          rank: 1
           type: DATE
         - label: Quel supplément vous a-t-on facturé ?
-          rank: 2
           type: TEXT
           placeholder: chambre double, télévision, repas spécifique...
         - label: Aviez-vous demandé ce supplément ?
-          rank: 3
           type: RADIO
           options:
             - Oui
             - Non
         - label: Quel est le prix de ce supplément ?
-          rank: 4
           type: TEXT
           optionnal: true
         - label: L'hôpital / clinique vous a t-il justifié ce supplément ?
-          rank: 5
           type: RADIO
           options:
             - Oui (à préciser)
@@ -480,10 +425,8 @@
             - LitigeContractuel
           detailInputs:
             - label: Date de constat
-              rank: 1
               type: DATE
             - label: Quel est le problème ? (plusieurs réponses possibles)
-              rank: 2
               type: CHECKBOX
               options:
                 - Les prix ne sont pas tous indiqués dans les rayons
@@ -530,10 +473,8 @@
                 - '411'
               detailInputs:
                 - label: Date du refus
-                  rank: 1
                   type: DATE
                 - label: Pouvez-vous nous décrire ce qu'il s'est passé ?
-                  rank: 2
                   type: TEXTAREA
               fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
         - title: Autre
@@ -566,10 +507,8 @@
             - '220'
           detailInputs:
             - label: Date de constat
-              rank: 1
               type: DATE
             - label: Quel est le problème ?
-              rank: 2
               type: RADIO
               options:
                 - les prix ne sont pas affichés du tout
@@ -585,10 +524,8 @@
             - '210'
           detailInputs:
             - label: Date de constat (ou date de paiement)
-              rank: 1
               type: DATE
             - label: Quel est le problème ?
-              rank: 2
               type: CHECKBOX
               options:
                 - les prix affichés ne sont pas à jour
@@ -603,10 +540,8 @@
             - '220'
           detailInputs:
             - label: Date de constat (ou date de paiement)
-              rank: 1
               type: DATE
             - label: Quel est le problème ?
-              rank: 2
               type: RADIO
               options:
                 - je n'ai pas eu de facture et je ne l'ai pas demandée
@@ -620,10 +555,8 @@
         - LitigeContractuel
       detailInputs:
         - label: Date de constat
-          rank: 1
           type: DATE
         - label: À propos de quoi est-ce trompeur ?
-          rank: 2
           type: CHECKBOX
           options:
             - un label (Qualicert) ou un certificat
@@ -632,7 +565,6 @@
             - spa simple déclaré en thalassothérapie
             - autre (à préciser)
         - label: Où avez-vous vu cette information (ou photo) que vous trouvez trompeuse ?
-          rank: 3
           type: RADIO
           options:
             - site internet ou publicité sur internet
@@ -640,7 +572,6 @@
             - affiche/ panneau publicitaire
             - autre (à préciser)
         - label: 'Expliquez en quelques mots pourquoi vous trouvez cela trompeur :'
-          rank: 4
           type: TEXT
       fileLabel: Merci de joindre tout document (photo, pdf) pouvant appuyer votre signalement.
     - title: Contrat
@@ -669,10 +600,8 @@
                 - '232'
               detailInputs:
                 - label: Date du refus
-                  rank: 1
                   type: DATE
                 - label: Pouvez-vous nous décrire ce qu'il s'est passé ?
-                  rank: 2
                   type: TEXTAREA
               fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
         - title: Autre

--- a/src/anomaly/yml/subcategories/services-aux-particuliers-old.yml
+++ b/src/anomaly/yml/subcategories/services-aux-particuliers-old.yml
@@ -44,11 +44,9 @@
             - LitigeContractuel
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Quel est le problème ?
-              rank: 2
               type: RADIO
               options:
                 - Les prix ne sont pas affichés
@@ -57,7 +55,6 @@
                 - Une promotion n''a pas été appliquée ou est fausse
                 - Autre (à préciser)
             - label: Si besoin, merci de préciser ce qu''il s''est passé
-              rank: 3
               type: TEXTAREA
               optionnal: true
           fileLabel: Vous pouvez joindre une photo des prix ou tout document utile pour appuyer votre signalement.

--- a/src/anomaly/yml/subcategories/services-aux-particuliers-old.yml
+++ b/src/anomaly/yml/subcategories/services-aux-particuliers-old.yml
@@ -56,7 +56,7 @@
                 - Autre (à préciser)
             - label: Si besoin, merci de préciser ce qu''il s''est passé
               type: TEXTAREA
-              optionnal: true
+              optional: true
           fileLabel: Vous pouvez joindre une photo des prix ou tout document utile pour appuyer votre signalement.
         - title: Moyens de paiement
           example: 'Exemple : carte bancaire refusée'

--- a/src/anomaly/yml/subcategories/services-aux-particuliers.yml
+++ b/src/anomaly/yml/subcategories/services-aux-particuliers.yml
@@ -66,7 +66,7 @@
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Référence abusive à des partenariats avec l'État ou de grandes entreprises
               ccrfCode:
                 - '23b'
@@ -85,7 +85,7 @@
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Utilisation de termes laissant croire qu'il s'agit d'une structure publique
               ccrfCode:
                 - '23b'
@@ -104,7 +104,7 @@
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Usurpation d'identité de la part du professionnel
               ccrfCode:
                 - '23b'
@@ -123,7 +123,7 @@
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
     - title: Contrat
       example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
       ccrfCode:
@@ -232,7 +232,7 @@
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Autre
     - title: Prix
       ccrfCode:

--- a/src/anomaly/yml/subcategories/services-aux-particuliers.yml
+++ b/src/anomaly/yml/subcategories/services-aux-particuliers.yml
@@ -21,20 +21,17 @@
             - DemarchageADomicile
           detailInputs:
             - label: Que s'est-il passé ?
-              rank: 1
               type: RADIO
               options:
                 - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
                 - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
                 - Autre (à préciser)
             - label: Avez-vous payé au moment du démarchage&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Oui
                 - Non
             - label: Date du démarchage
-              rank: 3
               type: DATE
               defaultValue: SYSDATE
         - title: Démarchage Téléphonique
@@ -56,7 +53,6 @@
                 - '210'
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -64,14 +60,11 @@
                     - Les documents mis à votre disposition par le professionnel (courrier, flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date de l'appel
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Référence abusive à des partenariats avec l'État ou de grandes entreprises
@@ -79,7 +72,6 @@
                 - '23b'
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -87,14 +79,11 @@
                     - Les documents mis à votre disposition par le professionnel (courrier, flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date de l'appel
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Utilisation de termes laissant croire qu'il s'agit d'une structure publique
@@ -102,7 +91,6 @@
                 - '23b'
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -110,14 +98,11 @@
                     - Les documents mis à votre disposition par le professionnel (courrier, flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date de l'appel
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Usurpation d'identité de la part du professionnel
@@ -125,7 +110,6 @@
                 - '23b'
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -133,14 +117,11 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date de l'appel
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
     - title: Contrat
@@ -210,20 +191,17 @@
             - DemarchageADomicile
           detailInputs:
             - label: Que s'est-il passé ?
-              rank: 1
               type: RADIO
               options:
                 - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
                 - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
                 - Autre (à préciser)
             - label: Avez-vous payé au moment du démarchage&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Oui
                 - Non
             - label: Date du démarchage
-              rank: 3
               type: DATE
               defaultValue: SYSDATE
         - title: Démarchage téléphonique
@@ -241,7 +219,6 @@
                 - '267'
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -249,14 +226,11 @@
                     - Les documents mis à votre disposition par le professionnel (courrier, flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date de l'appel
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure de l'appel (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Autre
@@ -280,7 +254,6 @@
             - '21b'
           detailInputs:
             - label: Veuillez préciser
-              rank: 1
               type: RADIO
               options:
                 - absence de Prix sur le devis
@@ -313,7 +286,6 @@
                 - '163'
               detailInputs:
                 - label: Veuillez préciser
-                  rank: 1
                   type: RADIO
                   options:
                     - absence de Prix sur le devis
@@ -360,7 +332,6 @@
                 - '163'
               detailInputs:
                 - label: Veuillez préciser
-                  rank: 1
                   type: RADIO
                   options:
                     - absence de Prix sur le devis
@@ -407,7 +378,6 @@
                 - '163'
               detailInputs:
                 - label: Veuillez préciser
-                  rank: 1
                   type: RADIO
                   options:
                     - absence de Prix sur le devis
@@ -455,18 +425,15 @@
                 - '21b'
               detailInputs:
                 - label: Veuillez préciser
-                  rank: 1
                   type: RADIO
                   options:
                     - absence de Prix sur le devis
                     - Prix illisible
                     - Autre (à préciser)
                 - label: Date du constat
-                  rank: 2
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Description
-                  rank: 3
                   type: TEXTAREA
         - title: Moyens de paiement
           example: 'Exemple : carte bancaire refusée'

--- a/src/anomaly/yml/subcategories/telephonie-media.yml
+++ b/src/anomaly/yml/subcategories/telephonie-media.yml
@@ -88,7 +88,7 @@
                         - "je n'ai rien reçu"
                     - label: Si vous avez reçu un courrier / email / sms, quelle est sa date ?
                       type: DATE
-                      optionnal: true
+                      optional: true
             - title: Le lien pour refuser l'augmentation de mon forfait ne fonctionne pas
               reponseconsoCode:
                 - '444'

--- a/src/anomaly/yml/subcategories/telephonie-media.yml
+++ b/src/anomaly/yml/subcategories/telephonie-media.yml
@@ -61,10 +61,8 @@
                         - LitigeContractuel
                       detailInputs:
                         - label: Date du début de l'option (vous pouvez préciser le premier mois facturé)
-                          rank: 1
                           type: DATE
                         - label: Quel est le nom de cette option ?
-                          rank: 2
                           type: TEXT
                           placeholder: "Indiquez l'intitulé figurant la facture"
                 - title: option liée à la musique, des livres, une chaine télé, un anti-virus
@@ -74,17 +72,13 @@
                     - LitigeContractuel
                   detailInputs:
                     - label: À partir de quand cette option va-t-elle être payante ?
-                      rank: 1
                       type: DATE
                     - label: Quel est le nom de cette option ?
-                      rank: 2
                       type: TEXT
                       placeholder: "Indiquez l'intitulé figurant sur l'email ou la facture"
                     - label: Quel est son prix ?
-                      rank: 3
                       type: TEXT
                     - label: Comment avez-vous été prévenu de cette option ?
-                      rank: 4
                       type: RADIO
                       options:
                         - email
@@ -93,7 +87,6 @@
                         - message dans l'espace client
                         - "je n'ai rien reçu"
                     - label: Si vous avez reçu un courrier / email / sms, quelle est sa date ?
-                      rank: 5
                       type: DATE
                       optionnal: true
             - title: Le lien pour refuser l'augmentation de mon forfait ne fonctionne pas
@@ -169,17 +162,14 @@
             - DemarchageTelephonique
           detailInputs:
             - label: Date de l'appel
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Non
                 - Oui (à préciser)
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 3
               type: TEXTAREA
     - title: Autre
       example: 'Exemple : téléphone acheté avec le forfait, service client injoignable'

--- a/src/anomaly/yml/subcategories/travaux-renovation.yml
+++ b/src/anomaly/yml/subcategories/travaux-renovation.yml
@@ -41,7 +41,6 @@
             - ReponseConso
           detailInputs:
             - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Le discours du professionnel
@@ -49,21 +48,17 @@
                 - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                 - Autre (à préciser)
             - label: À propos de quoi est-ce trompeur&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Le prix
                 - La nature des travaux de dépannage
                 - Les qualités et aptitudes du professionnel (artisans, normes...)
             - label: Description
-              rank: 3
               type: TEXTAREA
             - label: Date du constat
-              rank: 4
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 5
               type: TIMESLOT
               optionnal: true
         - title: Contrainte du professionnel
@@ -72,14 +67,11 @@
           detailInputs:
             - label: Précisez les informations sur le contexte
               example: 'Exemple : lieu de la rencontre, discours du professionnel, âge'
-              rank: 1
               type: TEXTAREA
             - label: Date du constat
-              rank: 2
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 3
               type: TIMESLOT
               optionnal: true
         - title: Autre
@@ -151,20 +143,17 @@
             - DemarchageADomicile
           detailInputs:
             - label: Que s'est-il passé ?
-              rank: 1
               type: RADIO
               options:
                 - Le vendeur s'est fait passer pour une autre entreprise (à préciser)
                 - Le vendeur m'a fait signer des papiers sans me dire que c'était un contrat ou un bon de commande.
                 - Autre (à préciser)
             - label: Avez-vous payé au moment du démarchage&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Oui
                 - Non
             - label: Date du démarchage
-              rank: 3
               type: DATE
               defaultValue: SYSDATE
         - title: Démarchage téléphonique
@@ -176,17 +165,14 @@
             - DemarchageTelephonique
           detailInputs:
             - label: Date de l'appel
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Est-ce que le vendeur s'est fait passer pour une autre entreprise&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Non
                 - Oui (à préciser)
             - label: Décrivez nous plus en détails ce qui s'est passé
-              rank: 3
               type: TEXTAREA
         - title: Information mensongère ou trompeuse
           reponseconsoCode:
@@ -197,7 +183,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -205,14 +190,11 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Référence abusive à des partenariats avec l'État ou de grandes entreprises d'énergie
@@ -220,7 +202,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -228,14 +209,11 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Utilisation de termes laissant croire qu'il s'agit d'une structure publique
@@ -243,7 +221,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -251,14 +228,11 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Usurpation d'identité de la part du professionnel
@@ -266,7 +240,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -274,14 +247,11 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Présentation des travaux comme étant obligatoires
@@ -289,7 +259,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -297,14 +266,11 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Promesse d'économies d'énergie surestimées
@@ -312,7 +278,6 @@
                 - ReponseConso
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -320,20 +285,16 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: Description
-                  rank: 2
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 3
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 4
                   type: TIMESLOT
                   optionnal: true
             - title: Autre
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-                  rank: 1
                   type: RADIO
                   options:
                     - Le discours du professionnel
@@ -341,21 +302,17 @@
                     - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                     - Autre (à préciser)
                 - label: À propos de quoi est-ce trompeur&#160;?
-                  rank: 2
                   type: RADIO
                   options:
                     - Le prix
                     - La nature des travaux
                     - Les qualités et aptitudes du professionnel (artisans, normes...)
                 - label: Description
-                  rank: 3
                   type: TEXTAREA
                 - label: Date du constat
-                  rank: 4
                   type: DATE
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
-                  rank: 5
                   type: TIMESLOT
                   optionnal: true
         - title: Contrainte du professionnel
@@ -364,14 +321,11 @@
           detailInputs:
             - label: Précisez les informations sur le contexte
               example: 'Exemple : lieu de la rencontre, discours du professionnel, âge'
-              rank: 1
               type: TEXTAREA
             - label: Date du constat
-              rank: 2
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 3
               type: TIMESLOT
               optionnal: true
         - title: Autre

--- a/src/anomaly/yml/subcategories/travaux-renovation.yml
+++ b/src/anomaly/yml/subcategories/travaux-renovation.yml
@@ -66,7 +66,6 @@
             - '210'
           detailInputs:
             - label: Précisez les informations sur le contexte
-              example: 'Exemple : lieu de la rencontre, discours du professionnel, âge'
               type: TEXTAREA
             - label: Date du constat
               type: DATE
@@ -320,7 +319,6 @@
             - '210'
           detailInputs:
             - label: Précisez les informations sur le contexte
-              example: 'Exemple : lieu de la rencontre, discours du professionnel, âge'
               type: TEXTAREA
             - label: Date du constat
               type: DATE

--- a/src/anomaly/yml/subcategories/travaux-renovation.yml
+++ b/src/anomaly/yml/subcategories/travaux-renovation.yml
@@ -60,7 +60,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
         - title: Contrainte du professionnel
           reponseconsoCode:
             - '210'
@@ -72,7 +72,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
         - title: Autre
           reponseconsoCode:
             - '210'
@@ -195,7 +195,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Référence abusive à des partenariats avec l'État ou de grandes entreprises d'énergie
               tags:
                 - ReponseConso
@@ -214,7 +214,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Utilisation de termes laissant croire qu'il s'agit d'une structure publique
               tags:
                 - ReponseConso
@@ -233,7 +233,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Usurpation d'identité de la part du professionnel
               tags:
                 - ReponseConso
@@ -252,7 +252,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Présentation des travaux comme étant obligatoires
               tags:
                 - ReponseConso
@@ -271,7 +271,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Promesse d'économies d'énergie surestimées
               tags:
                 - ReponseConso
@@ -290,7 +290,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
             - title: Autre
               detailInputs:
                 - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
@@ -313,7 +313,7 @@
                   defaultValue: SYSDATE
                 - label: Heure du constat (facultatif)
                   type: TIMESLOT
-                  optionnal: true
+                  optional: true
         - title: Contrainte du professionnel
           reponseconsoCode:
             - '210'
@@ -325,7 +325,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
         - title: Autre
     - title: Prestation
       example: 'Exemple : malfaçons sur le chantier, travaux commencés mais jamais terminés'

--- a/src/anomaly/yml/subcategories/voyage-loisirs.yml
+++ b/src/anomaly/yml/subcategories/voyage-loisirs.yml
@@ -295,7 +295,7 @@
               defaultValue: SYSDATE
             - label: "Numéro de réservation (pour faciliter le traitement par l'entreprise)"
               type: TEXT
-              optionnal: true
+              optional: true
             - label: Quel est le problème ?
               type: TEXTAREA
               placeholder: Quel était le prix initial ? Quel est le prix final ?
@@ -341,7 +341,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
     - title: Qualité de la chambre / de l'hébergement
       example: 'Exemple : hôtel sale, chambre insonorisée, pas de sauna alors que le site mentionne un sauna'
       tags:
@@ -555,7 +555,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
     - title: Prestation
       ccrfCode:
         - '23b'
@@ -686,7 +686,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
     - title: Retard / Annulation / Remboursement
       ccrfCode:
         - '21c'
@@ -809,7 +809,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
     - title: Contrat et abonnement
       example: 'Exemple : contrat non respecté, clause abusive'
       ccrfCode:
@@ -945,7 +945,7 @@
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
               type: TIMESLOT
-              optionnal: true
+              optional: true
     - title: Remboursement / annulation
       ccrfCode:
         - '21c'

--- a/src/anomaly/yml/subcategories/voyage-loisirs.yml
+++ b/src/anomaly/yml/subcategories/voyage-loisirs.yml
@@ -56,79 +56,61 @@
             - title: Je pense que le trajet n'était pas le plus direct
               detailInputs:
                 - label: Date de la course
-                  rank: 1
                   type: DATE
                 - label: Avez-vous demandé de prendre un itinéraire particulier en début de course ?
-                  rank: 2
                   type: RADIO
                   options:
                     - Oui
                     - Non
                 - label: Avez-vous fait remarquer au chauffeur que le chemin vous paraissait trop long en cours de route ? Si oui, merci de préciser sa réponse.
-                  rank: 3
                   type: RADIO
                   options:
                     - Oui (à préciser)
                     - Non
                 - label: Adresse de départ
-                  rank: 4
                   type: TEXT
                 - label: Heure de départ. Elle est normalement écrite sur la note (facture).
-                  rank: 5
                   type: TEXT
                 - label: Adresse d'arrivée
-                  rank: 6
                   type: TEXT
                 - label: Heure d'arrivée. Elle est normalement écrite sur la note (facture). Si vous la contestez, notez l'heure réelle d'arrivée.
-                  rank: 7
                   type: TEXT
                 - label: Notez le numéro ADS du taxi ou sa plaque d'immatriculation, si vous les connaissez.
-                  rank: 8
                   type: TEXT
                 - label: Si vous avez appelé une centrale de réservation, notez son nom.
-                  rank: 9
                   type: TEXT
                 - label: 'Ajoutez ici toute autre information utile à votre signalement.'
-                  rank: 10
                   type: TEXT
               fileLabel: Si possible, joindre une copie de la note (facture), et toute preuve du trajet réellement emprunté.
             - title: J'ai payé un supplément que je ne comprends pas
               detailInputs:
                 - label: Date de la course
-                  rank: 1
                   type: DATE
                 - label: Quel supplément avez-vous payé ?
-                  rank: 2
                   type: CHECKBOX
                   options:
                     - bagage
                     - passager supplémentaire
                     - animaux
                 - label: Combien étiez-vous de passagers (enfants compris) ?
-                  rank: 3
                   type: TEXT
                 - label: Combien aviez-vous de bagages en tout ?
-                  rank: 4
                   type: TEXT
             - title: Le prix au compteur était élevé dès la prise en charge
               tags:
                 - ReponseConso
               detailInputs:
                 - label: Date de la course
-                  rank: 1
                   type: DATE
                 - label: Adresse de départ
-                  rank: 2
                   type: TEXT
                 - label: Aviez-vous commandé votre taxi ?
-                  rank: 3
                   type: RADIO
                   options:
                     - Oui, je l'avais réservé
                     - Oui, je l'ai commandé juste avant de le prendre
                     - Non, il m'a pris en charge sur une place de taxi ou dans la rue
                 - label: Quel était le montant indiqué dès le départ ?
-                  rank: 4
                   type: TEXT
               fileLabel: Joindre si possible la note (facture) de votre course pour appuyer votre signalement.
             - title: Le taxi a fait un tarif de nuit / week-end alors que ce n'était pas le cas
@@ -136,25 +118,18 @@
                 - ReponseConso
               detailInputs:
                 - label: Date de la course
-                  rank: 1
                   type: DATE
                 - label: Adresse de départ
-                  rank: 2
                   type: TEXT
                 - label: Heure de départ. Elle est normalement écrite sur la note (facture).
-                  rank: 3
                   type: TEXT
                 - label: Adresse d'arrivée
-                  rank: 4
                   type: TEXT
                 - label: Heure d'arrivée
-                  rank: 5
                   type: TEXT
                 - label: Combien avez-vous payé ?
-                  rank: 6
                   type: TEXT
                 - label: Notez le numéro ADS du taxi ou sa plaque d'immatriculation, si vous les connaissez.
-                  rank: 8
                   type: TEXT
               fileLabel: Joindre si possible la note (facture) pour appuyer votre signalement.
             - title: Le chauffeur n'a pas appliqué le prix prévu pour le forfait
@@ -163,22 +138,16 @@
               example: Dans certaines villes, il existe des forfaits (c'est-à-dire un prix unique connu à l'avance) pour faire les trajets vers ou depuis un aéroport. Le prix de ces forfaits est fixe.
               detailInputs:
                 - label: Date de la course
-                  rank: 1
                   type: DATE
                 - label: Adresse de départ
-                  rank: 2
                   type: TEXT
                 - label: Adresse d'arrivée
-                  rank: 3
                   type: TEXT
                 - label: Quel est normalement le prix du forfait pour votre trajet ?
-                  rank: 4
                   type: TEXT
                 - label: Combien avez-vous payé ?
-                  rank: 5
                   type: TEXT
                 - label: Notez les éléments qui permettent d'identifier le taxi.
-                  rank: 6
                   type: TEXTAREA
                   placeholder: Numéro ADS, plaque d'immatriculation, entreprise de réservation...
               fileLabel: Joindre la note (facture) de votre course ou tout document utile pour appuyer votre signalement.
@@ -197,16 +166,12 @@
                 - title: Non
                   detailInputs:
                     - label: Date de la course
-                      rank: 1
                       type: DATE
                     - label: Comment avez-vous réglé votre course ?
-                      rank: 2
                       type: TEXT
                     - label: Notez le lieu de départ et le lieu d'arrivée
-                      rank: 3
                       type: TEXTAREA
                     - label: Merci de noter les informations pour identifier le véhicule
-                      rank: 4
                       type: TEXTAREA
                       placeholder: Immatriculation du véhicule, numéro ADS...
                   fileLabel: Joindre tout document utile pour appuyer votre signalement.
@@ -215,13 +180,10 @@
                 - LitigeContractuel
               detailInputs:
                 - label: Date de la course ?
-                  rank: 1
                   type: DATE
                 - label: Montant de la course ?
-                  rank: 2
                   type: TEXT
                 - label: Notez toute autre information utile.
-                  rank: 3
                   type: TEXT
                   placeholder: Identification du taxi, nom de la centrale d'appel...
               fileLabel: Joindre la note (facture) et tout document utile pour appuyer votre signalement (extrait de relevé bancaire).
@@ -245,14 +207,11 @@
             - '210'
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
             - label: Quelle était l'offre ou la promotion annoncée ?
-              rank: 2
               type: TEXT
               placeholder: 'Exemple : -20% offert à la première course'
             - label: Où avez-vous vu cette offre  ?
-              rank: 3
               type: RADIO
               options:
                 - site internet / application mobile de l'entreprise
@@ -260,7 +219,6 @@
                 - publicité sur un affichage (dans le métro, sur une pancarte...)
                 - autre (à préciser)
             - label: Quel est le problème ?
-              rank: 4
               type: TEXTAREA
           fileLabel: Merci de joindre tout document pouvant appuyer votre signalement (photographie de la publicité, reçu de votre course...)
         - title: Le prix payé n'est pas celui annoncé au départ
@@ -274,16 +232,12 @@
             - ReponseConso
           detailInputs:
             - label: Date de la course
-              rank: 1
               type: DATE
             - label: Quel était le prix annoncé au départ ?
-              rank: 2
               type: TEXT
             - label: Quel prix avez-vous payé ?
-              rank: 3
               type: TEXT
             - label: Le chauffeur / l'entreprise vous a-t-elle donné une raison ?
-              rank: 4
               type: RADIO
               options:
                 - Oui (à préciser)
@@ -337,15 +291,12 @@
             - LitigeContractuel
           detailInputs:
             - label: Date du constat
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: "Numéro de réservation (pour faciliter le traitement par l'entreprise)"
-              rank: 2
               type: TEXT
               optionnal: true
             - label: Quel est le problème ?
-              rank: 3
               type: TEXTAREA
               placeholder: Quel était le prix initial ? Quel est le prix final ?
           fileLabel: Vous pouvez joindre des éléments pour appuyer votre signalement.
@@ -371,7 +322,6 @@
             - '210'
           detailInputs:
             - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Le discours du professionnel
@@ -379,21 +329,17 @@
                 - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                 - Autre (à préciser)
             - label: À propos de quoi est-ce trompeur&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Le prix
                 - L'hébergement et ses prestations
                 - Autre (à préciser)
             - label: Description
-              rank: 3
               type: TEXTAREA
             - label: Date du constat
-              rank: 4
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 5
               type: TIMESLOT
               optionnal: true
     - title: Qualité de la chambre / de l'hébergement
@@ -523,11 +469,9 @@
           example: "Exemple : Refus pour un motif discriminatoire, au motif d'enfant"
           detailInputs:
             - label: Date du problème
-              rank: 1
               type: DATE
               defaultValue: SYSDATE
             - label: Pour quelle raison a-t-on refusé de vous donner une chambre ?
-              rank: 2
               type: TEXTAREA
           fileLabel: Vous pouvez joindre des éléments pour appuyer votre signalement.
         - title: Mon chien n'a pas été accepté
@@ -538,10 +482,8 @@
             - title: Oui (je possède la carte d'assistance)
               detailInputs:
                 - label: Date du refus
-                  rank: 1
                   type: DATE
                 - label: Pouvez-vous nous décrire ce qu'il s'est passé ?
-                  rank: 2
                   type: TEXTAREA
               fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
         - title: Le personnel est peu aimable
@@ -594,7 +536,6 @@
             - '210'
           detailInputs:
             - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Le discours du professionnel
@@ -602,21 +543,17 @@
                 - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                 - Autre (à préciser)
             - label: À propos de quoi est-ce trompeur&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Le prix
                 - L'hébergement et ses prestations
                 - Autre (à préciser)
             - label: Description
-              rank: 3
               type: TEXTAREA
             - label: Date du constat
-              rank: 4
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 5
               type: TIMESLOT
               optionnal: true
     - title: Prestation
@@ -730,7 +667,6 @@
             - '210'
           detailInputs:
             - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Le discours du professionnel
@@ -738,21 +674,17 @@
                 - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                 - Autre (à préciser)
             - label: À propos de quoi est-ce trompeur&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Le prix
                 - L'hébergement et ses prestations
                 - Autre (à préciser)
             - label: Description
-              rank: 3
               type: TEXTAREA
             - label: Date du constat
-              rank: 4
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 5
               type: TIMESLOT
               optionnal: true
     - title: Retard / Annulation / Remboursement
@@ -801,10 +733,8 @@
             - title: Oui (je possède la carte d'assistance)
               detailInputs:
                 - label: Date du refus
-                  rank: 1
                   type: DATE
                 - label: Pouvez-vous nous décrire ce qu'il s'est passé ?
-                  rank: 2
                   type: TEXTAREA
               fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
         - title: Autre
@@ -860,7 +790,6 @@
             - '210'
           detailInputs:
             - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Le discours du professionnel
@@ -868,21 +797,17 @@
                 - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                 - Autre (à préciser)
             - label: À propos de quoi est-ce trompeur&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Le prix
                 - L'hébergement et ses prestations
                 - Autre (à préciser)
             - label: Description
-              rank: 3
               type: TEXTAREA
             - label: Date du constat
-              rank: 4
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 5
               type: TIMESLOT
               optionnal: true
     - title: Contrat et abonnement
@@ -1001,7 +926,6 @@
             - '210'
           detailInputs:
             - label: Qu'est-ce qui est trompeur ou mensonger&#160;?
-              rank: 1
               type: RADIO
               options:
                 - Le discours du professionnel
@@ -1009,21 +933,17 @@
                 - Les documents mis à votre disposition par le professionnel (flyer, plaquette de présentation...)
                 - Autre (à préciser)
             - label: À propos de quoi est-ce trompeur&#160;?
-              rank: 2
               type: RADIO
               options:
                 - Le prix
                 - L'hébergement et ses prestations
                 - Autre (à préciser)
             - label: Description
-              rank: 3
               type: TEXTAREA
             - label: Date du constat
-              rank: 4
               type: DATE
               defaultValue: SYSDATE
             - label: Heure du constat (facultatif)
-              rank: 5
               type: TIMESLOT
               optionnal: true
     - title: Remboursement / annulation
@@ -1049,10 +969,8 @@
             - title: Oui (je possède la carte d'assistance)
               detailInputs:
                 - label: Date du refus
-                  rank: 1
                   type: DATE
                 - label: Pouvez-vous nous décrire ce qu'il s'est passé ?
-                  rank: 2
                   type: TEXTAREA
               fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
         - title: Autre

--- a/src/feature/Playground/PlaygroundDetails.tsx
+++ b/src/feature/Playground/PlaygroundDetails.tsx
@@ -8,47 +8,46 @@ import {UploadedFile} from '../../client/file/UploadedFile'
 import {DetailInputValue} from '../../client/report/Report'
 
 export class DetailsFixtureInput {
-  static readonly text: DetailInput = {
+  static readonly text = {
     label: 'Texte label',
     type: DetailInputType.TEXT,
   }
 
-  static readonly timeslot: DetailInput = {
+  static readonly timeslot = {
     label: 'Time',
     type: DetailInputType.TIMESLOT,
-    defaultValue: 'SYSDATE',
   }
 
-  static readonly date: DetailInput = {
+  static readonly date = {
     label: 'Date label',
     type: DetailInputType.DATE,
     defaultValue: 'SYSDATE',
   }
 
-  static readonly dateNotInFuture: DetailInput = {
+  static readonly dateNotInFuture = {
     label: 'Date (not in future) label',
     type: DetailInputType.DATE_NOT_IN_FUTURE,
     defaultValue: 'SYSDATE',
   }
 
-  static readonly dateWithNoDefault: DetailInput = {
+  static readonly dateWithNoDefault = {
     label: 'Date (without default to SYSDATE) label',
     type: DetailInputType.DATE,
   }
 
-  static readonly radio: DetailInput = {
+  static readonly radio = {
     label: 'Radio label',
     type: DetailInputType.RADIO,
     options: ['OPTION1', 'OPTION2 (à préciser)'],
   }
 
-  static readonly checkbox: DetailInput = {
+  static readonly checkbox = {
     label: 'Checkbox label',
     type: DetailInputType.CHECKBOX,
     options: ['CHECKBOX1', 'CHECKBOX2 (à préciser)', 'CHECKBOX3'],
   }
 
-  static readonly textarea: DetailInput = {
+  static readonly textarea = {
     label: 'Description',
     type: DetailInputType.TEXTAREA,
   }

--- a/src/feature/Playground/PlaygroundDetails.tsx
+++ b/src/feature/Playground/PlaygroundDetails.tsx
@@ -10,54 +10,46 @@ import {DetailInputValue} from '../../client/report/Report'
 export class DetailsFixtureInput {
   static readonly text: DetailInput = {
     label: 'Texte label',
-    rank: 1,
     type: DetailInputType.TEXT,
   }
 
   static readonly timeslot: DetailInput = {
     label: 'Time',
-    rank: 2,
     type: DetailInputType.TIMESLOT,
     defaultValue: 'SYSDATE',
   }
 
   static readonly date: DetailInput = {
     label: 'Date label',
-    rank: 2,
     type: DetailInputType.DATE,
     defaultValue: 'SYSDATE',
   }
 
   static readonly dateNotInFuture: DetailInput = {
     label: 'Date (not in future) label',
-    rank: 2,
     type: DetailInputType.DATE_NOT_IN_FUTURE,
     defaultValue: 'SYSDATE',
   }
 
   static readonly dateWithNoDefault: DetailInput = {
     label: 'Date (without default to SYSDATE) label',
-    rank: 2,
     type: DetailInputType.DATE,
   }
 
   static readonly radio: DetailInput = {
     label: 'Radio label',
-    rank: 3,
     type: DetailInputType.RADIO,
     options: ['OPTION1', 'OPTION2 (à préciser)'],
   }
 
   static readonly checkbox: DetailInput = {
     label: 'Checkbox label',
-    rank: 5,
     type: DetailInputType.CHECKBOX,
     options: ['CHECKBOX1', 'CHECKBOX2 (à préciser)', 'CHECKBOX3'],
   }
 
   static readonly textarea: DetailInput = {
     label: 'Description',
-    rank: 4,
     type: DetailInputType.TEXTAREA,
   }
 }

--- a/src/feature/Playground/PlaygroundDetails.tsx
+++ b/src/feature/Playground/PlaygroundDetails.tsx
@@ -3,51 +3,61 @@ import {_Details} from 'feature/Report/Details/Details'
 import React, {useState} from 'react'
 import {styleUtils} from 'core/theme/theme'
 import {ReportDraft2} from 'core/model/ReportDraft'
-import {DetailInput, DetailInputType} from '../../anomaly/Anomaly'
+import {
+  DetailInput,
+  DetailInputCheckbox,
+  DetailInputDate,
+  DetailInputDateNotInFuture,
+  DetailInputRadio,
+  DetailInputText,
+  DetailInputTextarea,
+  DetailInputTimeslot,
+  DetailInputType,
+} from '../../anomaly/Anomaly'
 import {UploadedFile} from '../../client/file/UploadedFile'
 import {DetailInputValue} from '../../client/report/Report'
 
 export class DetailsFixtureInput {
-  static readonly text = {
+  static readonly text: DetailInputText = {
     label: 'Texte label',
     type: DetailInputType.TEXT,
   }
 
-  static readonly timeslot = {
+  static readonly timeslot: DetailInputTimeslot = {
     label: 'Time',
     type: DetailInputType.TIMESLOT,
   }
 
-  static readonly date = {
+  static readonly date: DetailInputDate = {
     label: 'Date label',
     type: DetailInputType.DATE,
     defaultValue: 'SYSDATE',
   }
 
-  static readonly dateNotInFuture = {
+  static readonly dateNotInFuture: DetailInputDateNotInFuture = {
     label: 'Date (not in future) label',
     type: DetailInputType.DATE_NOT_IN_FUTURE,
     defaultValue: 'SYSDATE',
   }
 
-  static readonly dateWithNoDefault = {
+  static readonly dateWithNoDefault: DetailInputDate = {
     label: 'Date (without default to SYSDATE) label',
     type: DetailInputType.DATE,
   }
 
-  static readonly radio = {
+  static readonly radio: DetailInputRadio = {
     label: 'Radio label',
     type: DetailInputType.RADIO,
     options: ['OPTION1', 'OPTION2 (à préciser)'],
   }
 
-  static readonly checkbox = {
+  static readonly checkbox: DetailInputCheckbox = {
     label: 'Checkbox label',
     type: DetailInputType.CHECKBOX,
     options: ['CHECKBOX1', 'CHECKBOX2 (à préciser)', 'CHECKBOX3'],
   }
 
-  static readonly textarea = {
+  static readonly textarea: DetailInputTextarea = {
     label: 'Description',
     type: DetailInputType.TEXTAREA,
   }

--- a/src/feature/Report/Details/DetailInputsUtils.ts
+++ b/src/feature/Report/Details/DetailInputsUtils.ts
@@ -1,0 +1,23 @@
+import {DetailInputType} from 'model'
+import {DetailInput} from 'model'
+
+export const getDefaultValueFromInput = (detailInput: DetailInput): string | undefined => {
+  if (detailInput.type === DetailInputType.DATE || detailInput.type === DetailInputType.DATE_NOT_IN_FUTURE) {
+    return detailInput.defaultValue
+  }
+  return undefined
+}
+
+export const getPlaceholderFromInput = (detailInput: DetailInput): string | undefined => {
+  if (detailInput.type === DetailInputType.TEXT || detailInput.type === DetailInputType.TEXTAREA) {
+    return detailInput.placeholder
+  }
+  return undefined
+}
+
+export const getOptionsFromInput = (detailInput: DetailInput): string[] | undefined => {
+  if (detailInput.type === DetailInputType.CHECKBOX || detailInput.type === DetailInputType.RADIO) {
+    return detailInput.options
+  }
+  return undefined
+}

--- a/src/feature/Report/Details/Details.tsx
+++ b/src/feature/Report/Details/Details.tsx
@@ -143,7 +143,7 @@ export const _Details = ({
           {inputs.map((input, inputIndex) => (
             <FormLayout
               label={<span dangerouslySetInnerHTML={{__html: input.label}} />}
-              required={!input.optionnal}
+              required={!input.optional}
               key={inputIndex}
               sx={{
                 mb: 3,
@@ -165,7 +165,7 @@ export const _Details = ({
                       name={'' + inputIndex}
                       defaultValue={defaultValue ?? input.defaultValue}
                       rules={{
-                        required: {value: !input.optionnal, message: m.required + ' *'},
+                        required: {value: !input.optional, message: m.required + ' *'},
                         ...rules,
                       }}
                       render={render}

--- a/src/feature/Report/Details/Details.tsx
+++ b/src/feature/Report/Details/Details.tsx
@@ -30,7 +30,8 @@ import {EventCategories, ReportEventActions} from 'core/analytic/analytic'
 import {FileOrigin, UploadedFile} from '../../../client/file/UploadedFile'
 import {DetailInput, DetailInputType, ReportTag, SubcategoryInput} from '../../../anomaly/Anomaly'
 import {ReportDraft} from '../../../client/report/ReportDraft'
-import {dateToFrenchFormat, frenchFormatToDate, isDateInRange} from 'core/helper/utils'
+import {dateToFrenchFormat, isDateInRange} from 'core/helper/utils'
+import {getDefaultValueFromInput, getOptionsFromInput, getPlaceholderFromInput} from './DetailInputsUtils'
 
 export class SpecifyFormUtils {
   static readonly keyword = '(à préciser)'
@@ -163,7 +164,7 @@ export const _Details = ({
                     <Controller
                       control={control}
                       name={'' + inputIndex}
-                      defaultValue={defaultValue ?? input.defaultValue}
+                      defaultValue={defaultValue ?? getDefaultValueFromInput(input)}
                       rules={{
                         required: {value: !input.optional, message: m.required + ' *'},
                         ...rules,
@@ -178,7 +179,7 @@ export const _Details = ({
                 const renderDateVariant = ({max}: {max: string}) => {
                   const min = '01/01/1970'
                   return controller({
-                    defaultValue: input.defaultValue === 'SYSDATE' ? dateToFrenchFormat(new Date()) : undefined,
+                    defaultValue: getDefaultValueFromInput(input) === 'SYSDATE' ? dateToFrenchFormat(new Date()) : undefined,
                     rules: {
                       validate: (d: string) => {
                         return isDateInRange(d, min, max) ? true : m.invalidDate
@@ -188,7 +189,7 @@ export const _Details = ({
                       <ScDatepicker
                         {...field}
                         fullWidth
-                        placeholder={input.placeholder}
+                        placeholder={getPlaceholderFromInput(input)}
                         min={min}
                         max={max}
                         helperText={errorMessage}
@@ -215,7 +216,7 @@ export const _Details = ({
                           <ScSelect
                             {...field}
                             fullWidth
-                            placeholder={input.placeholder}
+                            placeholder={getPlaceholderFromInput(input)}
                             helperText={errorMessage}
                             error={hasErrors}
                           >
@@ -231,7 +232,7 @@ export const _Details = ({
                       controller({
                         render: ({field}) => (
                           <ScRadioGroup {...field} sx={{mt: 1}} dense helperText={errorMessage} error={hasErrors}>
-                            {input.options?.map((option, i) => (
+                            {getOptionsFromInput(input)?.map((option, i) => (
                               <ScRadioGroupItem
                                 key={option}
                                 value={option}
@@ -255,7 +256,7 @@ export const _Details = ({
                       controller({
                         render: ({field}) => (
                           <ScRadioGroup {...field} multiple helperText={errorMessage} error={hasErrors} sx={{mt: 1}} dense>
-                            {input.options?.map(option => (
+                            {getOptionsFromInput(input)?.map(option => (
                               <ScRadioGroupItem
                                 key={option}
                                 value={option}
@@ -281,7 +282,9 @@ export const _Details = ({
                         rules: {
                           maxLength: {value: appConfig.maxDescriptionInputLength, message: ''},
                         },
-                        render: ({field}) => <ScInput {...field} error={hasErrors} fullWidth placeholder={input.placeholder} />,
+                        render: ({field}) => (
+                          <ScInput {...field} error={hasErrors} fullWidth placeholder={getPlaceholderFromInput(input)} />
+                        ),
                       }),
                   },
                   () =>
@@ -302,7 +305,7 @@ export const _Details = ({
                           minRows={5}
                           maxRows={10}
                           fullWidth
-                          placeholder={input.placeholder}
+                          placeholder={getPlaceholderFromInput(input)}
                         />
                       ),
                     }),

--- a/src/feature/Report/Details/draftReportInputs.ts
+++ b/src/feature/Report/Details/draftReportInputs.ts
@@ -11,7 +11,7 @@ export class DraftReportDefaultInputs {
   static readonly description = (optional?: boolean): DetailInput => ({
     label: 'Description',
     type: DetailInputType.TEXTAREA,
-    ...(optional && {optionnal: true}),
+    ...(optional && {optional: true}),
   })
 
   static readonly date = (): DetailInput => ({

--- a/src/pages/arborescence.tsx
+++ b/src/pages/arborescence.tsx
@@ -2,6 +2,7 @@ import {Box, Checkbox, Icon, Radio, useTheme} from '@mui/material'
 import {sortBy} from 'core/lodashNamedExport'
 import {pageDefinitions} from 'core/pageDefinition'
 import {styleUtils} from 'core/theme/theme'
+import {getOptionsFromInput, getPlaceholderFromInput} from 'feature/Report/Details/DetailInputsUtils'
 import Head from 'next/head'
 import {useEffect, useState} from 'react'
 import {ScButton} from 'shared/Button/Button'
@@ -126,7 +127,7 @@ const NodeInput = ({anomaly}: {anomaly: SubcategoryInput}) => {
             {
               [DetailInputType.RADIO]: () => (
                 <>
-                  {input.options!.map(option => (
+                  {getOptionsFromInput(input)!.map(option => (
                     <Box key={option} sx={{display: 'flex', alignItems: 'center'}}>
                       <Radio disabled size="small" sx={{mr: 1, p: 1 / 4}} />
                       <Txt size="small">{option}</Txt>
@@ -136,7 +137,7 @@ const NodeInput = ({anomaly}: {anomaly: SubcategoryInput}) => {
               ),
               [DetailInputType.CHECKBOX]: () => (
                 <>
-                  {input.options!.map(option => (
+                  {getOptionsFromInput(input)!.map(option => (
                     <Box key={option} sx={{display: 'flex', alignItems: 'center'}}>
                       <Checkbox disabled size="small" sx={{mr: 1, p: 1 / 4}} />
                       <Txt size="small">{option}</Txt>
@@ -156,7 +157,7 @@ const NodeInput = ({anomaly}: {anomaly: SubcategoryInput}) => {
                   border: t => `1px solid ${t.palette.divider}`,
                 }}
               >
-                {input.placeholder ?? '...'}
+                {getPlaceholderFromInput(input) ?? '...'}
               </Box>
             ),
           )}


### PR DESCRIPTION
Les objects "detailInputs" venant du YAML avaient pas mal de champs différents. En fait certains champs étaient obsolètes ("rank"), et toutes les combinaisons de champs n'étaient pas possibles, ils n'étaient utilisés que par certains sous types (placeholder pour TEXT, defaultValue pour DATE, etc.). J'ai nettoyé et corrigé tout ça.