### PR TITLE
MEP (TRELLO-1399 Rework choice for LitigeContractuel (#258))

### DIFF
--- a/src/anomalies/Anomaly.ts
+++ b/src/anomalies/Anomaly.ts
@@ -23,7 +23,7 @@ export interface Anomaly extends Category {
 }
 
 export interface SubcategoryBase extends Category {
-  tags?: ReportTag[]
+  tags?: ReportTagAllowedInYaml[]
   example?: string
   reponseconsoCode?: string[] | null
   ccrfCode?: string[]
@@ -41,8 +41,7 @@ export interface SubcategoryInformation extends SubcategoryBase {
   information: Information
 }
 
-export const reportTags = [
-  'LitigeContractuel',
+export const reportTagsAllowedInYaml = [
   'Hygiene',
   'ProduitDangereux',
   'DemarchageADomicile',
@@ -58,6 +57,9 @@ export const reportTags = [
   'ProduitAlimentaire',
   'CompagnieAerienne',
 ] as const
+export type ReportTagAllowedInYaml = typeof reportTagsAllowedInYaml[number]
+
+export const reportTags = ['LitigeContractuel', ...reportTagsAllowedInYaml] as const
 export type ReportTag = typeof reportTags[number]
 
 export const companyKinds = ['SIRET', 'WEBSITE', 'PHONE', 'LOCATION', 'SOCIAL'] as const

--- a/src/anomalies/script/checkAnomaliesJson.ts
+++ b/src/anomalies/script/checkAnomaliesJson.ts
@@ -1,4 +1,4 @@
-import {companyKinds, CompanyKinds, DetailInputType, ReportTag, reportTags} from '../Anomaly'
+import {companyKinds, CompanyKinds, DetailInputType, ReportTag, reportTags, reportTagsAllowedInYaml} from '../Anomaly'
 import {AnomalyTreeWalker, ObjectSpec} from './AnomalyTreeWalker'
 
 // /!\ This effectively duplicates the structure
@@ -33,7 +33,7 @@ const anomalySpec: ObjectSpec = {
 }
 
 const baseSubcategorySpec: ObjectSpec = {
-  tags: _ => _.ifDefined()?.assertIsArrayOfAllowedStrings(reportTags),
+  tags: _ => _.ifDefined()?.assertIsArrayOfAllowedStrings(reportTagsAllowedInYaml),
   example: _ => _.ifDefined()?.assertIsString(),
   reponseconsoCode: _ => _.ifDefined()?.ifNotNull()?.assertIsArrayOfString(),
   ccrfCode: _ => _.ifDefined()?.assertIsArrayOfString(),

--- a/src/anomalies/yml/subcategories/achat-magasin.yml
+++ b/src/anomalies/yml/subcategories/achat-magasin.yml
@@ -501,8 +501,6 @@
           example: 'Exemple : le magasin refuse de me reprendre un article'
           ccrfCode:
             - '21D'
-          tags:
-            - LitigeContractuel
           subcategoriesTitle: Pourquoi voulez-vous retourner ou échanger votre article ?
           subcategories:
             - title: Il présente un défaut ou il ne marche plus

--- a/src/anomalies/yml/subcategories/animaux.yml
+++ b/src/anomalies/yml/subcategories/animaux.yml
@@ -3,22 +3,17 @@
   reponseconsoCode:
     - '332'
     - '617'
-  tags:
-    - LitigeContractuel
 - title: Soins
   example: 'Exemple : vétérinaire, toiletteur'
   reponseconsoCode:
     - '212'
     - '213'
-  tags:
-    - LitigeContractuel
 - title: Garde d'animaux
   example: "Exemple : pension, site internet de garde d'animaux"
   reponseconsoCode:
     - '212'
     - '213'
   tags:
-    - LitigeContractuel
     - ReponseConso
 - title: Vendeur d'animaux
   reponseconsoCode:
@@ -26,10 +21,7 @@
     - '271'
   tags:
     - ReponseConso
-    - LitigeContractuel
 - title: Autre
   reponseconsoCode:
     - '333'
     - '210'
-  tags:
-    - LitigeContractuel

--- a/src/anomalies/yml/subcategories/banque-assurance-mutuelle.yml
+++ b/src/anomalies/yml/subcategories/banque-assurance-mutuelle.yml
@@ -2,7 +2,6 @@
   example: 'Exemple : banque classique, banque en ligne'
   tags:
     - ReponseConso
-    - LitigeContractuel
   subcategories:
     - title: Frais bancaires
       example: 'Exemple : prix non affiché, augmentation des frais bancaires sans prévenir'
@@ -19,8 +18,6 @@
       reponseconsoCode:
         - '210'
         - '411'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Démarchage téléphonique
           companyKind: PHONE
@@ -67,7 +64,6 @@
     - title: Publicité
       example: 'Exemple : publicité trompeuse, démarchage à domicile, démarchage téléphonique'
       tags:
-        - LitigeContractuel
         - ReponseConso
       subcategories:
         - title: Démarchage à domicile
@@ -122,13 +118,9 @@
       example: 'Exemple : service client injoignable'
       reponseconsoCode:
         - '491'
-      tags:
-        - LitigeContractuel
     - title: Autre
       reponseconsoCode:
         - '679'
-      tags:
-        - LitigeContractuel
 - title: Assurance maladie (sécurité sociale)
   information:
     title: Vous ne pouvez pas utiliser SignalConso pour signaler un problème avec l'assurance maladie.

--- a/src/anomalies/yml/subcategories/cafe-restaurant.yml
+++ b/src/anomalies/yml/subcategories/cafe-restaurant.yml
@@ -153,8 +153,6 @@
     - title: J'ai payé plus cher que le prix affiché
       reponseconsoCode:
         - '212'
-      tags:
-        - LitigeContractuel
       detailInputs:
         - label: Date du constat
           type: DATE

--- a/src/anomalies/yml/subcategories/demarches-administratives.yml
+++ b/src/anomalies/yml/subcategories/demarches-administratives.yml
@@ -12,7 +12,6 @@
     - '511'
   tags:
     - ReponseConso
-    - LitigeContractuel
 - title: Site internet pour obtenir un document administratif (casier, acte de naissance, vignette crit'air)
   subcategoriesTitle: À qui appartient ce site internet&#160;?
   subcategories:
@@ -26,7 +25,6 @@
         - '511'
       tags:
         - ReponseConso
-        - LitigeContractuel
 - title: Carte des numéros utiles de la mairie (numéro urgence serrurier, plombier...)
   reponseconsoCode:
     - '210'
@@ -46,5 +44,3 @@
         - '521'
         - '210'
         - '492'
-      tags:
-        - LitigeContractuel

--- a/src/anomalies/yml/subcategories/demo.yml
+++ b/src/anomalies/yml/subcategories/demo.yml
@@ -22,11 +22,8 @@
     - '23F'
     - '146'
 - title: Sous category pour tester divers tags
-  example: Pour tester les tags LitigeContractuel, ReponseConso, etc.
+  example: Pour tester les tags ReponseConso, ProduitDangereux, etc.
   subcategories:
-    - title: Sous cat avec tag LitigeContractuel
-      tags:
-        - LitigeContractuel
     - title: Sous cat avec tag ReponseConso
       tags:
         - ReponseConso

--- a/src/anomalies/yml/subcategories/eau-gaz-electricite.yml
+++ b/src/anomalies/yml/subcategories/eau-gaz-electricite.yml
@@ -6,8 +6,6 @@
         - title: Le distributeur refuse de m'ouvrir un contrat car je suis locataire et non propriétaire
         - title: Le distributeur me demande de payer une avance sur ma consommation
           subcategoriesTitle: Quand doit-être remboursée cette avance ?
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Elle sera déduite à ma première facture d'eau
               information:
@@ -33,7 +31,6 @@
         - title: Une clause du contrat (règlement de service) est abusive, c'est-à-dire qu'elle désavantage fortement le consommateur.
           tags:
             - ReponseConso
-            - LitigeContractuel
           detailInputs:
             - label: Date du constat (ou du contrat)
               type: DATE
@@ -44,12 +41,10 @@
         - title: Autre
           tags:
             - ReponseConso
-            - LitigeContractuel
     - title: Coupure de l'eau pour impayé
       example: Mon débit d'eau a été réduit car je ne peux payer ma facture
       tags:
         - ReponseConso
-        - LitigeContractuel
       detailInputs:
         - label: Date du contrat
           type: DATE
@@ -96,8 +91,6 @@
             - label: Décrivez nous plus en détails ce qui s'est passé
               type: TEXTAREA
 - title: Gaz / Electricité
-  tags:
-    - LitigeContractuel
   subcategories:
     - title: Démarchage à domicile
       example: 'Exemple : vendeur prétend être envoyé par EDF, démarcheur agressif'
@@ -275,5 +268,4 @@
     - '271'
     - '212'
   tags:
-    - LitigeContractuel
     - ReponseConso

--- a/src/anomalies/yml/subcategories/immobilier.yml
+++ b/src/anomalies/yml/subcategories/immobilier.yml
@@ -9,14 +9,12 @@
             - title: Diffusion d'annonces de location pour des biens non disponibles (en vitrine ou sur internet)
               tags:
                 - ReponseConso
-                - LitigeContractuel
               reponseconsoCode:
                 - '210'
                 - '220'
             - title: Honoraires de location non affichés ou différents de ceux affichés (en vitrine ou sur internet)
               tags:
                 - ReponseConso
-                - LitigeContractuel
               reponseconsoCode:
                 - '212'
                 - '220'
@@ -24,7 +22,6 @@
               example: "Exemple : loyer annoncé faux, descriptif de l'appartement mensonger"
               tags:
                 - ReponseConso
-                - LitigeContractuel
               reponseconsoCode:
                 - '210'
                 - '220'
@@ -37,7 +34,6 @@
             - title: Autre
               tags:
                 - ReponseConso
-                - LitigeContractuel
               reponseconsoCode:
                 - '679'
         - title: Je cherche à acheter
@@ -55,7 +51,6 @@
                 - '220'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Annonces de vente incomplètes ou mensongères (en vitrine ou sur internet)
               reponseconsoCode:
                 - '210'
@@ -63,14 +58,12 @@
               example: "Exemple : absence de DPE, descriptif d'un appartement mensonger"
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Problème avec une offre d'achat ou un compromis de vente
               reponseconsoCode:
                 - '425'
               example: 'Exemple : refus de mon offre au prix sans justification'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Cas particulier d'un chasseur d'appartements
               example: "Exemple : frais d'étude alors que c'est interdit"
               reponseconsoCode:
@@ -78,18 +71,14 @@
                 - '425'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Cas particulier d'un mandataire indépendant (agent commercial)
               reponseconsoCode:
                 - '2269'
                 - '425'
               tags:
                 - ReponseConso
-                - LitigeContractuel
     - title: J'ai un problème en tant que locataire
       example: 'Exemple : état des lieux, charges, loyer'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Charges / honoraires
           reponseconsoCode:
@@ -115,8 +104,6 @@
       example: 'Exemple : gestion locative, mise en vente'
       subcategories:
         - title: Gestion locative
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Contrat et mandat
               tags:
@@ -156,19 +143,15 @@
                 - '451'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Discours trompeur
               example: "Exemple : L'agent immobilier m'a promis de vendre sous 7 jours"
               reponseconsoCode:
                 - '210'
               tags:
                 - ReponseConso
-                - LitigeContractuel
         - title: Autre
           reponseconsoCode:
             - '679'
-          tags:
-            - LitigeContractuel
     - title: Autre
       subcategories:
         - title: Problème d'accessibilité de l'agence
@@ -211,7 +194,6 @@
         - title: J'ai pris connaissance de mon contrat de syndic.
           tags:
             - ReponseConso
-            - LitigeContractuel
           subcategories:
             - title: Les frais sont plus chers que dans le contrat
             - title: Les frais ne correspondent à aucune des prestations dites "prestations particulières".
@@ -231,8 +213,6 @@
       example: 'Exemple: devis, choix des prestataires'
       reponseconsoCode:
         - '633'
-      tags:
-        - LitigeContractuel
     - title: Absence de réponse du syndic
       example: 'Exemple : aucune réponse malgré des relances'
       reponseconsoCode:
@@ -240,16 +220,11 @@
     - title: Autre
       reponseconsoCode:
         - '679'
-      tags:
-        - LitigeContractuel
 - title: Notaire
   reponseconsoCode:
     - '679'
   tags:
-    - LitigeContractuel
     - ReponseConso
 - title: Autre
   reponseconsoCode:
     - '679'
-  tags:
-    - LitigeContractuel

--- a/src/anomalies/yml/subcategories/sante.yml
+++ b/src/anomalies/yml/subcategories/sante.yml
@@ -1,7 +1,5 @@
 - title: Produit de santé
   example: 'Exemple : médicament, bas de contention, prothèse, lunette, pansement, fauteuil roulant, compléments alimentaires, autres produits achetés en pharmacie ou rayon pharmacie'
-  tags:
-    - LitigeContractuel
   subcategories:
     - title: J'ai eu un problème de santé / sécurité avec un produit
       example: 'Exemple : allergie, vomissement, électrocution'
@@ -112,8 +110,6 @@
           type: TEXT
 - title: Professionnel de la santé et médecine douce
   example: 'Exemple : dentiste, opticien, kiné, psychiatre, médecine douce'
-  tags:
-    - LitigeContractuel
   subcategoriesTitle: 'Quel type de médecine exerce-t-il ?'
   subcategories:
     - title: La médecine dite "conventionnelle"
@@ -361,8 +357,6 @@
             - '226'
             - '220'
 - title: Hôpital / Clinique
-  tags:
-    - LitigeContractuel
   subcategories:
     - title: J'ai subi un mauvais traitement ou j'ai été mal soigné
       information:
@@ -422,7 +416,6 @@
             - '226'
           tags:
             - ReponseConso
-            - LitigeContractuel
           detailInputs:
             - label: Date de constat
               type: DATE
@@ -447,15 +440,11 @@
           reponseconsoCode:
             - '226'
             - '162'
-          tags:
-            - LitigeContractuel
     - title: Problème de commande
       reponseconsoCode:
         - '220'
         - '226'
         - '162'
-      tags:
-        - LitigeContractuel
     - title: Autre
       subcategories:
         - title: Problème d'accessibilité
@@ -485,7 +474,6 @@
   example: 'et autre transport sanitaire (exemple : taxi)'
   tags:
     - ReponseConso
-    - LitigeContractuel
   reponseconsoCode:
     - '212'
     - '226'
@@ -496,7 +484,6 @@
       example: "Exemple : les prix ne sont pas affichés, pas de remise d'une facture"
       tags:
         - ReponseConso
-        - LitigeContractuel
       subcategories:
         - title: Les prix ne sont pas affichés
           example: 'Exemple : les prix des soins ne sont pas affichés, les prix affichés ne sont pas très clairs'
@@ -551,8 +538,6 @@
       reponseconsoCode:
         - '210'
         - '220'
-      tags:
-        - LitigeContractuel
       detailInputs:
         - label: Date de constat
           type: DATE
@@ -581,7 +566,6 @@
         - '422'
       tags:
         - ReponseConso
-        - LitigeContractuel
     - title: Autre
       subcategories:
         - title: Problème d'accessibilité

--- a/src/anomalies/yml/subcategories/services-aux-particuliers.yml
+++ b/src/anomalies/yml/subcategories/services-aux-particuliers.yml
@@ -69,16 +69,12 @@
                 - autre (à préciser)
     - title: Publicité et pratique du professionnel
       example: "Exemple : absence d'information, information trompeuse ou mensongère"
-      tags:
-        - LitigeContractuel
       ccrfCode:
         - '23B'
       subcategories:
         - title: Absence d'information ou information incomplète
           ccrfCode:
             - '23B'
-          tags:
-            - LitigeContractuel
         - title: Information mensongère ou trompeuse
           example: "Mise en avant d'un label ou d'un signe de qualité non ou plus détenu"
           ccrfCode:
@@ -186,33 +182,23 @@
                 content: Vous avez signé le contrat sur un stand de l'entreprise dans une foire ou un salon. Il n'y a pas de délai de rétractation dans ce cas.
                 outOfScope: true
         - title: Contrat non respecté
-          tags:
-            - LitigeContractuel
         - title: Clause abusive
           example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
           ccrfCode:
             - '21C'
-          tags:
-            - LitigeContractuel
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Autre
 - title: Service de lutte contre les rats, les punaises de lits, désinfection
   example: 'Exemple : la désinfection, la désinsectisation, la dératisation, lutte contre les nuisibles'
   subcategories:
     - title: Publicité et pratique du professionnel
       example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage"
-      tags:
-        - LitigeContractuel
       ccrfCode:
         - '23B'
       subcategories:
         - title: Absence d'information ou information incomplète
           ccrfCode:
             - '23b'
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Caractéristiques techniques des produits non précisées
             - title: Prix indiqué de manière globale et non détaillée
@@ -334,8 +320,6 @@
         - title: Publicité des prestations mensongère
           ccrfCode:
             - '23b'
-          tags:
-            - LitigeContractuel
         - title: Le personnel ne dispose pas des diplômes requis
           ccrfCode:
             - '23F'
@@ -346,8 +330,6 @@
             - title: Je subis des nuisances à cause des odeurs, du bruit...
               information: !!import/single ../common/info/voisinage.yml
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Le personnel n'est pas aimable
           information: !!import/single ../common/info/amabilite.yml
     - title: Esthéticien
@@ -380,8 +362,6 @@
         - title: Publicité des prestations mensongère
           ccrfCode:
             - '23b'
-          tags:
-            - LitigeContractuel
         - title: Le personnel ne dispose pas des diplômes requis
           ccrfCode:
             - '23F'
@@ -392,8 +372,6 @@
             - title: Je subis des nuisances à cause des odeurs, du bruit...
               information: !!import/single ../common/info/voisinage.yml
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Le personnel n'est pas aimable
           information: !!import/single ../common/info/amabilite.yml
     - title: Cabine UV
@@ -426,8 +404,6 @@
         - title: Publicité des prestations mensongère
           ccrfCode:
             - '23b'
-          tags:
-            - LitigeContractuel
         - title: Le personnel ne dispose pas des diplômes requis
           ccrfCode:
             - '23F'
@@ -438,8 +414,6 @@
             - title: Je subis des nuisances à cause des odeurs, du bruit...
               information: !!import/single ../common/info/voisinage.yml
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Le personnel n'est pas aimable
           information: !!import/single ../common/info/amabilite.yml
     - title: Massage
@@ -478,8 +452,6 @@
         - title: Publicité des prestations mensongère
           ccrfCode:
             - '23b'
-          tags:
-            - LitigeContractuel
         - title: Le personnel ne dispose pas des diplômes requis
           ccrfCode:
             - '23F'
@@ -490,8 +462,6 @@
             - title: Je subis des nuisances à cause des odeurs, du bruit...
               information: !!import/single ../common/info/voisinage.yml
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Le personnel n'est pas aimable
           information: !!import/single ../common/info/amabilite.yml
 - title: Vie quotidienne
@@ -504,8 +474,6 @@
       reponseconsoCode:
         - '411'
         - '212'
-      tags:
-        - LitigeContractuel
     - title: Moyens de paiement
       example: 'Exemple : carte bancaire refusée'
       subcategories: !!import/single ../common/paiement.yml
@@ -516,7 +484,6 @@
         - '210'
       tags:
         - ReponseConso
-        - LitigeContractuel
     - title: Problème d'hygiène
       reponseconsoCode:
         - '446'
@@ -528,8 +495,6 @@
     - title: Autre
       reponseconsoCode:
         - '210'
-      tags:
-        - LitigeContractuel
 - title: Aide à la personne
   example: "Garde d'enfant de moins de 3 ans, garde d'enfants handicapés de moins de 18 ans, garde de personnes âgées dépendantes ou handicapées, services d'aide et d'accompagnement à domicile (SAAD)"
   subcategories:
@@ -540,8 +505,6 @@
       reponseconsoCode:
         - '411'
         - '212'
-      tags:
-        - LitigeContractuel
     - title: Moyens de paiement
       example: 'Exemple : carte bancaire refusée'
       subcategories: !!import/single ../common/paiement.yml
@@ -559,17 +522,13 @@
         - '210'
       tags:
         - ReponseConso
-        - LitigeContractuel
     - title: Le personnel n'est pas aimable
       information: !!import/single ../common/info/amabilite.yml
     - title: Autre
       reponseconsoCode:
         - '210'
-      tags:
-        - LitigeContractuel
 - title: Maison de retraite (ehpad)
   tags:
-    - LitigeContractuel
     - Ehpad
   subcategories:
     - title: Tarifs / facture
@@ -695,7 +654,6 @@
         - '212'
       tags:
         - ReponseConso
-        - LitigeContractuel
     - title: Moyens de paiement
       example: 'Exemple : carte bancaire refusée'
       subcategories: !!import/single ../common/paiement.yml
@@ -709,7 +667,6 @@
         - '210'
       tags:
         - ReponseConso
-        - LitigeContractuel
     - title: Le personnel n'est pas aimable ou respecteux
       information: !!import/single ../common/info/amabilite.yml
     - title: Le personnel ne dispose pas des diplômes requis
@@ -734,14 +691,11 @@
         - '442'
       tags:
         - ReponseConso
-        - LitigeContractuel
     - title: Agence matrimoniale (agence de rencontre)
       reponseconsoCode:
         - '2263'
         - '473'
         - '226'
-      tags:
-        - LitigeContractuel
     - title: Autre
       reponseconsoCode:
         - '210'

--- a/src/anomalies/yml/subcategories/telephonie-media.yml
+++ b/src/anomalies/yml/subcategories/telephonie-media.yml
@@ -21,13 +21,11 @@
                 - title: Non, j'ai reçu seulement un sms
                   tags:
                     - ReponseConso
-                    - LitigeContractuel
                 - title: Non, je n'ai rien reçu du tout
                   reponseconsoCode:
                     - '421'
                   tags:
                     - ReponseConso
-                    - LitigeContractuel
             - title: Modification concernant les sms, mms ou appels
               tags:
                 - ReponseConso
@@ -46,15 +44,11 @@
                   reponseconsoCode:
                     - '421'
                     - '2202'
-                  tags:
-                    - LitigeContractuel
                 - title: Non, je n'ai rien reçu du tout
                   ccrfCode:
                     - '421'
                   reponseconsoCode:
                     - '421'
-                  tags:
-                    - LitigeContractuel
             - title: Rajout d'une option payante
               example: 'Exemple : chaine télé supplémentaire, option cyber-sécurité, option livre audio, option musique...'
               ccrfCode:
@@ -73,8 +67,6 @@
                     - title: Non, je n'ai rien reçu
                       ccrfCode:
                         - '421'
-                      tags:
-                        - LitigeContractuel
                       detailInputs:
                         - label: Date du début de l'option (vous pouvez préciser le premier mois facturé)
                           type: DATE
@@ -86,8 +78,6 @@
                     - '226'
                   reponseconsoCode:
                     - '421'
-                  tags:
-                    - LitigeContractuel
                   detailInputs:
                     - label: À partir de quand cette option va-t-elle être payante ?
                       type: DATE
@@ -117,7 +107,6 @@
                 - '210'
               tags:
                 - ReponseConso
-                - LitigeContractuel
         - title: L'offre / la promotion que je devais avoir n'a pas été appliquée
           ccrfCode:
             - '23B'
@@ -126,7 +115,6 @@
             - '210'
           tags:
             - ReponseConso
-            - LitigeContractuel
         - title: Autre problème de facturation ou de contrat
           ccrfCode:
             - '23B'
@@ -135,7 +123,6 @@
             - '623'
           tags:
             - ReponseConso
-            - LitigeContractuel
           subcategories:
             - title: Utilisation de mon forfait à l'étranger
               reponseconsoCode:
@@ -151,8 +138,6 @@
         title: La qualité du réseau est mauvaise
         content: Les problèmes de réseau ou d'éligibilité ne peuvent pas être signalés sur SignalConso. <br> Vous devez les signaler à l'ARCEP (Autorité de régulation des communications électroniques, des postes et de la distribution de la presse) sur leur site dédié  <a href="https://jalerte.arcep.fr/" target="_blank" /> J'alerte l'Arcep </a>
     - title: Résiliation / changement d'opérateur
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Frais de résiliation
           ccrfCode:
@@ -210,7 +195,6 @@
       example: 'Exemple : téléphone acheté avec le forfait, service client injoignable'
       tags:
         - ReponseConso
-        - LitigeContractuel
       subcategories:
         - title: Qualité du service client
           example: 'Exemple : pas de réponse du service client, service client payant'

--- a/src/anomalies/yml/subcategories/travaux-renovation.yml
+++ b/src/anomalies/yml/subcategories/travaux-renovation.yml
@@ -1,7 +1,5 @@
 - title: Dépannage
   example: "Vous faites appel à une entreprise dans l'urgence à votre domicile (par exemple : vous avez perdu votre clef d'appartement et vous contactez un serrurier pour qu'il vienne vous l'ouvrir, vous appelez un plombier suite à l'explosion de votre canalisation)"
-  tags:
-    - LitigeContractuel
   subcategories:
     - title: Prix
       ccrfCode:
@@ -101,7 +99,6 @@
         - '23E'
       reponseconsoCode:
         - '221'
-      tags:
       #            - ReponseConso
         - DemarchageTelephonique
       detailInputs:
@@ -122,8 +119,6 @@
         ccrfCode:
           - '21B'
           - '213'
-        tags:
-         - LitigeContractuel
         subcategories:
           - title: Prix exagéré / élevé
             information:
@@ -145,8 +140,6 @@
               - ReponseConso
       - title: Publicité et pratique de l'entreprise
         example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage à domicile"
-        tags:
-          - LitigeContractuel
         ccrfCode:
           - '21A'
           - '23B'
@@ -158,7 +151,6 @@
             ccrfCode:
               - '271'
             tags:
-              - LitigeContractuel
               - ReponseConso
             subcategories:
               - title: Caractéristiques techniques des produits non précisées
@@ -394,8 +386,6 @@
             reponseconsoCode:
               - '443'
               - '442'
-            tags:
-              - LitigeContractuel
       - title: Contrat
         example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
         subcategories:
@@ -461,8 +451,6 @@
             reponseconsoCode:
               - '443'
               - '446'
-            tags:
-              - LitigeContractuel
           - title: Clause abusive
             example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
             ccrfCode:
@@ -471,14 +459,9 @@
               - '214'
             tags:
               - ReponseConso
-              - LitigeContractuel
           - title: Autre
-            tags:
-              - LitigeContractuel
       - title: Crédits pour les travaux / garanties
         example: "Défaut d'information, absence de remise du contrat de crédit, engagement financier mensuel supérieur à celui annoncé par le vendeur, annonce d'autofinancement de l'installation"
-        tags:
-          - LitigeContractuel
         subcategories:
           - title: Crédit destiné à financer vos travaux
             ccrfCode:
@@ -529,8 +512,6 @@
                   - '411'        
               - title: Responsabilité contractuelle de droit commun
       - title: Autre
-        tags:
-          - LitigeContractuel
     - title: chauffage
       example: "Par exemple : pompe à chaleur, chauffage au bois, chauffe-eau thermodynamique"
       subcategories:
@@ -539,8 +520,6 @@
           ccrfCode:
             - '21B'
             - '213'
-          tags:
-          - LitigeContractuel
           subcategories:
             - title: Prix exagéré / élevé
               information:
@@ -562,15 +541,12 @@
                 - ReponseConso
         - title: Publicité et pratique de l'entreprise
           example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage à domicile"
-          tags:
-            - LitigeContractuel
           ccrfCode:
             - '21A'
             - '23B'
           subcategories:
             - title: Absence d'information ou information incomplète
               tags:
-                - LitigeContractuel
                 - ReponseConso
               subcategories:
                 - title: Caractéristiques techniques des produits non précisées
@@ -809,8 +785,6 @@
                 - '2213'
                 - '2214'
                 - '2216'
-              tags:
-                - LitigeContractuel
         - title: Contrat
           example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
           subcategories:
@@ -872,8 +846,6 @@
                 - '226'
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
             - title: Clause abusive
               example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
               ccrfCode:
@@ -882,16 +854,11 @@
                 - '214'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Crédits pour les travaux / garanties
           example: "Défaut d'information, absence de remise du contrat de crédit, engagement financier mensuel supérieur à celui annoncé par le vendeur, annonce d'autofinancement de l'installation"
           ccrfCode:
             - '21A'
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Crédit destiné à financer vos travaux
               example: Crédit affecté au contrat de travaux / rénovation
@@ -936,8 +903,6 @@
                 - title: Garantie décennale
                 - title: Responsabilité contractuelle de droit commun
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Isolation
       example: "L'isolation des murs, des combles, du garage/sous-sol, le remplacement de portes/fenêtres"
       subcategories:
@@ -946,8 +911,6 @@
           ccrfCode:
             - '21B'
             - '213'
-          tags:
-          - LitigeContractuel
           subcategories:
             - title: Prix exagéré / élevé
               information:
@@ -968,15 +931,12 @@
                 - ReponseConso
         - title: Publicité et pratique de l'entreprise
           example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage"
-          tags:
-            - LitigeContractuel
           ccrfCode:
             - '21A'
             - '23B'
           subcategories:
             - title: Absence d'information ou information incomplète
               tags:
-                - LitigeContractuel
                 - ReponseConso
               subcategories:
                 - title: Caractéristiques techniques des produits non précisées
@@ -1209,8 +1169,6 @@
             - title: Les travaux ne sont toujours pas terminés
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
         - title: Contrat
           example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
           subcategories:
@@ -1269,8 +1227,6 @@
                 - '226'
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
             - title: Clause abusive
               example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
               ccrfCode:
@@ -1279,16 +1235,11 @@
                 - '214'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Crédits pour les travaux / garanties
           example: "Défaut d'information, absence de remise du contrat de crédit, engagement financier mensuel supérieur à celui annoncé par le vendeur, annonce d'autofinancement de l'installation"
           ccrfCode:
             - '21A'
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Crédit financé pour vos travaux
               example: Crédit affecté au contrat de travaux / rénovation
@@ -1333,8 +1284,6 @@
                 - title: Garantie décennale
                 - title: Responsabilité contractuelle de droit commun
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Ventilation
       subcategories:
         - title: Prix
@@ -1342,8 +1291,6 @@
           ccrfCode:
             - '21B'
             - '213'
-          tags:
-          - LitigeContractuel
           subcategories:
             - title: Prix exagéré / élevé
               information:
@@ -1364,15 +1311,12 @@
                 - ReponseConso
         - title: Publicité et pratique de l'entreprise
           example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage"
-          tags:
-            - LitigeContractuel
           ccrfCode:
             - '21A'
             - '23B'
           subcategories:
             - title: Absence d'information ou information incomplète
               tags:
-                - LitigeContractuel
                 - ReponseConso
               subcategories:
                 - title: Caractéristiques techniques des produits non précisées
@@ -1605,8 +1549,6 @@
             - title: Les travaux ne sont toujours pas terminés
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
         - title: Contrat
           example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
           subcategories:
@@ -1662,8 +1604,6 @@
                 - '226'
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
             - title: Clause abusive
               example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
               ccrfCode:
@@ -1672,14 +1612,9 @@
                 - '214'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Crédits pour les travaux / garanties
           example: "Défaut d'information, absence de remise du contrat de crédit, engagement financier mensuel supérieur à celui annoncé par le vendeur, annonce d'autofinancement de l'installation"
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Crédit financé pour vos travaux
               example: Crédit affecté au contrat de travaux / rénovation
@@ -1720,8 +1655,6 @@
                 - title: Garantie décennale
                 - title: Responsabilité contractuelle de droit commun
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Production d'énergies renouvelables
       example: L'instation d'équipements solaire, petites éoliennes domestiques
       subcategories:
@@ -1729,8 +1662,6 @@
           example: 'Exemple : prix non affiché, devis non respecté'
           ccrfCode:
             - '21B'
-          tags:
-          - LitigeContractuel
           subcategories:
             - title: Prix exagéré / élevé
               information:
@@ -1751,14 +1682,11 @@
                 - ReponseConso
         - title: Publicité et pratique de l'entreprise
           example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage"
-          tags:
-            - LitigeContractuel
           ccrfCode:
             - '23B'
           subcategories:
             - title: Absence d'information ou information incomplète
               tags:
-                - LitigeContractuel
                 - ReponseConso
               subcategories:
                 - title: Caractéristiques techniques des produits non précisées
@@ -1989,8 +1917,6 @@
             - title: Les travaux ne sont toujours pas terminés
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
         - title: Contrat
           example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
           subcategories:
@@ -2046,8 +1972,6 @@
                 - '226'
               reponseconsoCode:
                 - '443'
-              tags:
-                - LitigeContractuel
             - title: Clause abusive
               example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
               ccrfCode:
@@ -2056,14 +1980,9 @@
                 - '214'
               tags:
                 - ReponseConso
-                - LitigeContractuel
             - title: Autre
-              tags:
-                - LitigeContractuel
         - title: Crédits pour les travaux / garanties
           example: "Défaut d'information, absence de remise du contrat de crédit, engagement financier mensuel supérieur à celui annoncé par le vendeur, annonce d'autofinancement de l'installation"
-          tags:
-            - LitigeContractuel
           subcategories:
             - title: Crédit financé pour vos travaux
               example: Crédit affecté au contrat de travaux / rénovation
@@ -2104,8 +2023,6 @@
                 - title: Garantie décennale
                 - title: Responsabilité contractuelle de droit commun
         - title: Autre
-          tags:
-            - LitigeContractuel
 - title: Autres Travaux
   example: "Par exemple : la construction de votre maison ou l'adaptation de votre logement à un handicape ou pour une personne âgée"
   subcategories:
@@ -2113,8 +2030,6 @@
       example: 'Exemple : prix non affiché, devis non respecté'
       ccrfCode:
         - '21B'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Prix exagéré / élevé
           information:
@@ -2135,15 +2050,12 @@
             - ReponseConso
     - title: Publicité et pratique de l'entreprise
       example: "Exemple : absence d'information, information trompeuse ou mensongère, démarchage à domicile"
-      tags:
-        - LitigeContractuel
       ccrfCode:
         - '21A'
         - '23B'
       subcategories:
         - title: Absence d'information ou information incomplète
           tags:
-            - LitigeContractuel
             - ReponseConso
           subcategories:
             - title: Caractéristiques techniques des produits non précisées
@@ -2374,8 +2286,6 @@
         - title: Les travaux ne sont toujours pas terminés
           reponseconsoCode:
             - '443'
-          tags:
-            - LitigeContractuel
     - title: Contrat
       example: 'Exemple : contrat non respecté, délai de rétractation, clause abusive'
       subcategories:
@@ -2431,8 +2341,6 @@
             - '226'
           reponseconsoCode:
             - '443'
-          tags:
-            - LitigeContractuel
         - title: Clause abusive
           example: Vous souhaitez dénoncer une clause qui vous est particulièrement défavorable
           ccrfCode:
@@ -2441,14 +2349,9 @@
             - '214'
           tags:
             - ReponseConso
-            - LitigeContractuel
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Crédits pour les travaux / garanties
       example: "Défaut d'information, absence de remise du contrat de crédit, engagement financier mensuel supérieur à celui annoncé par le vendeur, annonce d'autofinancement de l'installation"
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Crédit financé pour vos travaux
           example: Crédit affecté au contrat de travaux / rénovation
@@ -2493,8 +2396,6 @@
             - title: Garantie décennale
             - title: Responsabilité contractuelle de droit commun
     - title: Autre
-      tags:
-        - LitigeContractuel
 - title: Produit dangereux
   example: 'Exemple : marteau, perceuse'
   tags:

--- a/src/anomalies/yml/subcategories/voiture-vehicule.yml
+++ b/src/anomalies/yml/subcategories/voiture-vehicule.yml
@@ -1,12 +1,8 @@
 - title: Location
   example: 'Exemple : location de voiture, location de vélo, location longue durée'
-  tags:
-    - LitigeContractuel
   subcategories:
     - title: Location de voiture auprès d'une agence ou d'un magasin
       example: "Exemple : agence à l'aéroport, location de camionnette dans un supermarché, plate-forme de location sur internet"
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Prix / paiement
           reponseconsoCode:
@@ -30,8 +26,6 @@
             - title: Autre
     - title: Location en libre-service
       example: 'Exemple : location de vélo, trotinette, voiture électrique par une borne'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Prix / paiement
           reponseconsoCode:
@@ -48,8 +42,6 @@
           reponseconsoCode:
             - '679'
     - title: Location longue durée (leasing, LDD, LOA...)
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Prix / paiement
           reponseconsoCode:
@@ -85,8 +77,6 @@
             - '679'
 - title: Réparation, révision, vente de véhicule
   example: 'Exemple : garagiste, dépanneur, contrôle technique'
-  tags:
-    - LitigeContractuel
   subcategories:
     - title: Prix / paiement
       reponseconsoCode:

--- a/src/anomalies/yml/subcategories/voyage-loisirs.yml
+++ b/src/anomalies/yml/subcategories/voyage-loisirs.yml
@@ -9,8 +9,6 @@
       subcategories:
         - title: Refus de faire la course
           example: "Exemple : le taxi refuse de vous prendre car ce n'est pas assez loin"
-          tags:
-            - LitigeContractuel
           ccrfCode:
             - '23e'
           reponseconsoCode:
@@ -51,7 +49,6 @@
             - '164'
           tags:
             - ReponseConso
-            - LitigeContractuel
           subcategories:
             - title: Je pense que le trajet n'était pas le plus direct
               detailInputs:
@@ -176,8 +173,6 @@
                       placeholder: Immatriculation du véhicule, numéro ADS...
                   fileLabel: Joindre tout document utile pour appuyer votre signalement.
             - title: J'ai été prélevé deux fois
-              tags:
-                - LitigeContractuel
               detailInputs:
                 - label: Date de la course ?
                   type: DATE
@@ -190,13 +185,9 @@
             - title: Le chauffeur n'était pas aimable
               information: !!import/single ../common/info/amabilite.yml
             - title: Autre
-              tags:
-                - LitigeContractuel
     - title: VTC (voiture avec chauffeur)
       companyKind: 'WEBSITE'
       example: Les VTC n'ont pas de signe particulier sur les voitures. Vous devez faire une réservation pour prendre un VTC. La plupart de ces réservations se font sur internet.
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Une remise ou une offre promotionnelle qui n'est pas appliquée ou qui est mensongère
           ccrfCode:
@@ -288,7 +279,6 @@
           example: 'Exemple : fausse réduction, supplément imprévu'
           tags:
             - ReponseConso
-            - LitigeContractuel
           detailInputs:
             - label: Date du constat
               type: DATE
@@ -301,13 +291,10 @@
               placeholder: Quel était le prix initial ? Quel est le prix final ?
           fileLabel: Vous pouvez joindre des éléments pour appuyer votre signalement.
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Informations concernant le logement / Publicité
       example: "Exemple : publicité trompeuse, absence d'information"
       tags:
         - ReponseConso
-        - LitigeContractuel
       subcategories:
         - title: Absence d'information
           ccrfCode:
@@ -344,8 +331,6 @@
               optional: true
     - title: Qualité de la chambre / de l'hébergement
       example: 'Exemple : hôtel sale, chambre insonorisée, pas de sauna alors que le site mentionne un sauna'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: L'hébergement ne correspond pas à ce qui m'a été vendu
           example: "Exemple : j'avais demandé une chambre avec vue sur la mer et on m'a attribué une vue côté parking, le petit-déjeuner était compris dans le prix de la nuitée or un supplément m'a été demandé"
@@ -375,8 +360,6 @@
         - '453'
         - '481'
         - '4241'
-      tags:
-        - LitigeContractuel
       subcategoriesTitle: Qui a annulé la réservation&#160;?
       subcategories:
         - title: l'hôtel, le camping, le gérant...
@@ -516,17 +499,13 @@
             - '210'
           tags:
             - ReponseConso
-            - LitigeContractuel
         - title: Autre
-          tags:
-            - LitigeContractuel
     - title: Publicité
       example: "Exemple : publicité trompeuse, absence d'information"
       ccrfCode:
         - '23b'
       tags:
         - ReponseConso
-        - LitigeContractuel
       subcategories:
         - title: Absence d'information
           reponseconsoCode:
@@ -559,8 +538,6 @@
     - title: Prestation
       ccrfCode:
         - '23b'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: La prestation ne correspond pas à ce que l'agence m'a vendu
           reponseconsoCode:
@@ -577,8 +554,6 @@
         - '481'
         - '4241'
         - '424'
-      tags:
-        - LitigeContractuel
     - title: Assurance
       ccrfCode:
         - '21a'
@@ -587,11 +562,7 @@
         - '481'
         - '4241'
         - '424'
-      tags:
-        - LitigeContractuel
     - title: Autre
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Le personnel n'était pas aimable
           information: !!import/single ../common/info/amabilite.yml
@@ -641,17 +612,13 @@
           example: 'Exemple : fausse réduction, suppléments non prévus'
           tags:
             - ReponseConso
-            - LitigeContractuel
           reponseconsoCode:
             - '210'
         - title: Autre
           tags:
             - ReponseConso
-            - LitigeContractuel
     - title: Publicité
       example: "Exemple : publicité trompeuse, absence d'information"
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Absence d'information
           ccrfCode:
@@ -694,11 +661,7 @@
         - '481'
         - '424'
         - '4241'
-      tags:
-        - LitigeContractuel
     - title: Assurance
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Annulation
           ccrfCode:
@@ -717,8 +680,6 @@
       example: 'Exemple : TGV max, pass Navigo'
       ccrfCode:
         - '21c'
-      tags:
-        - LitigeContractuel
     - title: Autre
       subcategories:
         - title: Le personnel n'était pas aimable
@@ -738,8 +699,6 @@
                   type: TEXTAREA
               fileLabel: Vous pouvez joindre des éléments (photo, carte d'assistance...) pour appuyer votre signalement.
         - title: Autre
-          tags:
-            - LitigeContractuel
 - title: Sport
   example: 'Exemple : piscine, salle de sport'
   subcategories:
@@ -767,16 +726,13 @@
             - '210'
           tags:
             - ReponseConso
-            - LitigeContractuel
         - title: Autre
           tags:
             - ReponseConso
-            - LitigeContractuel
     - title: Publicité
       example: "Exemple : publicité trompeuse, absence d'information"
       tags:
         - ReponseConso
-        - LitigeContractuel
       subcategories:
         - title: Absence d'information
           ccrfCode:
@@ -814,8 +770,6 @@
       example: 'Exemple : contrat non respecté, clause abusive'
       ccrfCode:
         - '21c'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Clause abusive
           reponseconsoCode:
@@ -861,8 +815,6 @@
     - title: Autre
       ccrfCode:
         - '332'
-      tags:
-        - LitigeContractuel
       subcategories:
         - title: Equipement
         - title: Compléments alimentaires
@@ -905,18 +857,15 @@
             - '210'
           tags:
             - ReponseConso
-            - LitigeContractuel
         - title: Autre
           tags:
             - ReponseConso
-            - LitigeContractuel
     - title: Publicité
       example: "Exemple : publicité mensongère, absence d'information"
       ccrfCode:
         - '23b'
       tags:
         - ReponseConso
-        - LitigeContractuel
       subcategories:
         - title: Absence d'information
           reponseconsoCode:
@@ -953,8 +902,6 @@
         - '424'
         - '4241'
         - '481'
-      tags:
-        - LitigeContractuel
     - title: Autre
       subcategories:
         - title: Problème d'accessibilité
@@ -976,10 +923,8 @@
         - title: Autre
           tags:
             - ReponseConso
-            - LitigeContractuel
 - title: Autre
   tags:
-    - LitigeContractuel
     - ReponseConso
   subcategories:
     - title: Abonnement

--- a/src/components_feature/Playground/PlaygroundDetails.tsx
+++ b/src/components_feature/Playground/PlaygroundDetails.tsx
@@ -117,6 +117,7 @@ export const PlaygroundDetails = () => {
               setResultFiles(files)
             }}
             stepNavigation={dummyStepNavigation}
+            consumerWish={undefined}
           />
         </CardContent>
       </Card>

--- a/src/components_feature/Report/Confirmation/Confirmation.tsx
+++ b/src/components_feature/Report/Confirmation/Confirmation.tsx
@@ -138,7 +138,7 @@ export const _Confirmation = ({
         <ReportFlowStepperActions
           nextIcon="send"
           loadingNext={_reportCreate.createReport.loading}
-          nextButtonLabel={draft.forwardToReponseConso ? m.confirmationBtnReponseConso : m.confirmationBtn}
+          nextButtonLabel={draft.consumerWish === 'getAnswer' ? m.confirmationBtnReponseConso : m.confirmationBtn}
           next={next => {
             _analytic.trackEvent(EventCategories.report, ReportEventActions.validateConfirmation)
             _reportCreate.createReport

--- a/src/components_feature/Report/Consumer/Consumer.tsx
+++ b/src/components_feature/Report/Consumer/Consumer.tsx
@@ -69,7 +69,7 @@ export const _Consumer = ({
   const {isXsOrLess} = useWindowWidth()
   const {toastError} = useToast()
 
-  const showContactAgreement = ReportDraft.isTransmittableToPro(draft) && draft.contractualDispute !== true
+  const showContactAgreement = ReportDraft.isTransmittableToPro(draft) && draft.consumerWish !== 'fixContractualDispute'
 
   const getErrors = (name: keyof ConsumerForm): {error: boolean; helperText?: string} => ({
     error: !!_form.formState.errors[name],
@@ -83,7 +83,7 @@ export const _Consumer = ({
       consumer: consumer,
       contactAgreement: (() => {
         if (!ReportDraft.isTransmittableToPro(draft)) return false
-        if (draft.contractualDispute) return true
+        if (draft.consumerWish === 'fixContractualDispute') return true
         return contactAgreement
       })(),
     })

--- a/src/components_feature/Report/Details/Details.test.tsx
+++ b/src/components_feature/Report/Details/Details.test.tsx
@@ -46,6 +46,7 @@ describe('Details: single date not in future', () => {
           inputValues = x
         }}
         stepNavigation={dummyStepNavigation}
+        consumerWish={undefined}
       />,
     )
   })
@@ -91,6 +92,7 @@ describe('Details: checkbox', () => {
           inputValues = x
         }}
         stepNavigation={dummyStepNavigation}
+        consumerWish={undefined}
       />,
     )
   })
@@ -152,6 +154,7 @@ describe('Details: textarea', () => {
           inputValues = x
         }}
         stepNavigation={dummyStepNavigation}
+        consumerWish={undefined}
       />,
     )
   })
@@ -208,6 +211,7 @@ describe('Details: initialize values', () => {
           inputValues = x
         }}
         stepNavigation={dummyStepNavigation}
+        consumerWish={undefined}
       />,
     )
   })

--- a/src/components_feature/Report/Details/draftReportInputs.test.ts
+++ b/src/components_feature/Report/Details/draftReportInputs.test.ts
@@ -15,7 +15,7 @@ describe('getDraftReportInputs', () => {
   it('should generate default inputs including reponseConso inputs', () => {
     const inputs = getDraftReportInputs({
       subcategories: [Fixture.genSubcategory()],
-      tags: ['ReponseConso'],
+      consumerWish: 'getAnswer',
     })
     expect(inputs).toEqual([
       DraftReportDefaultInputs.date(),
@@ -33,7 +33,7 @@ describe('getDraftReportInputs', () => {
 
   it('should generate custom input with reponseconso', () => {
     const inputs = getDraftReportInputs({
-      tags: ['ReponseConso'],
+      consumerWish: 'getAnswer',
       subcategories: [Fixture.genSubcategory(), {id: '', title: '', detailInputs: [DetailsFixtureInput.date]}],
     })
     expect(inputs).toEqual([

--- a/src/components_feature/Report/Details/draftReportInputs.ts
+++ b/src/components_feature/Report/Details/draftReportInputs.ts
@@ -1,3 +1,4 @@
+import {ReportDraft2} from 'model/ReportDraft2'
 import {last} from 'utils/lodashNamedExport'
 import {instanceOfSubcategoryInput} from '../../../anomalies/Anomalies'
 import {DetailInput, DetailInputType, ReportTag, Subcategory} from '../../../anomalies/Anomaly'
@@ -23,13 +24,8 @@ export class DraftReportDefaultInputs {
   static readonly defaults = (): DetailInput[] => [DraftReportDefaultInputs.date(), DraftReportDefaultInputs.description()]
 }
 
-export const getDraftReportInputs = ({
-  subcategories,
-  tags,
-}: {
-  subcategories: Subcategory[]
-  tags?: ReportTag[]
-}): DetailInput[] => {
+export const getDraftReportInputs = (draft: Partial<ReportDraft2>): DetailInput[] => {
+  const {subcategories, consumerWish} = draft
   const lastSubcategories = last(subcategories)
   const res: DetailInput[] = []
   if (instanceOfSubcategoryInput(lastSubcategories)) {
@@ -40,7 +36,7 @@ export const getDraftReportInputs = ({
   } else {
     res.push(...DraftReportDefaultInputs.defaults())
   }
-  if (tags?.includes('ReponseConso')) {
+  if (consumerWish === 'getAnswer') {
     const i = res.findIndex(
       _ => _.type === DetailInputType.TEXTAREA && !_.label.includes(DraftReportDefaultInputs.description().label),
     )

--- a/src/components_feature/Report/Problem/Problem.test.tsx
+++ b/src/components_feature/Report/Problem/Problem.test.tsx
@@ -282,8 +282,8 @@ describe('Problem', () => {
     expectContractualDisputeVisible(app, false)
     clickBtnSubmit(app)
     expect(report?.employeeConsumer).toEqual(false)
-    expect(report?.forwardToReponseConso).toEqual(true)
-    expect(report?.tags?.includes('ReponseConso')).toEqual(true)
+    expect(report?.consumerWish).toEqual('getAnswer')
+    expect(report?.tags?.includes('ReponseConso')).toEqual(false)
   })
 
   it('should ask add ReponseConso tag when related option is not selected', () => {
@@ -303,7 +303,7 @@ describe('Problem', () => {
     expectContractualDisputeVisible(app, false)
     clickBtnSubmit(app)
     expect(report?.employeeConsumer).toEqual(false)
-    expect(report?.forwardToReponseConso).not.toEqual(true)
+    expect(report?.consumerWish).not.toEqual('getAnswer')
     expect((report?.tags ?? []).includes('ReponseConso')).toEqual(false)
   })
 })

--- a/src/model/ReportDraft2.tsx
+++ b/src/model/ReportDraft2.tsx
@@ -15,7 +15,7 @@ export interface ReportDraft2 extends Omit<ReportDraft, 'details'> {
 
 export class ReportDraft2 {
   static readonly toReportDraft = (d: ReportDraft2): ReportDraft => {
-    const inputs = getDraftReportInputs({subcategories: d.subcategories, tags: d.tags})
+    const inputs = getDraftReportInputs(d)
     return {
       ...d,
       details: ReportDraft2.parseDetails(d.details, inputs),

--- a/src/model/ReportStep.ts
+++ b/src/model/ReportStep.ts
@@ -66,7 +66,7 @@ export function getAnalyticsForStep(step: ReportStepOrDone) {
 function isBuildingStepDone(r: Partial<ReportDraft2>, step: ReportStep) {
   switch (step) {
     case 'BuildingProblem':
-      return !!r.category && !!r.subcategories && !!r.contractualDispute !== undefined && r.employeeConsumer !== undefined
+      return !!r.category && !!r.subcategories && !!r.consumerWish
     case 'BuildingDetails':
       return !!r.details
     case 'BuildingCompany':


### PR DESCRIPTION
Changement fonctionnel :
avant, le tag LitigeContractuel et l'option "Résoudre mon problème personnel avec l'entreprise" était totalement décorrélés. Le tag LitigeContractuel issu de l'arborescence YAML était transmis tel quel dans le signalement, que l'option soit choisie ou non. maintenant, le tag LitigeContractuel est appliqué quand l'option "Résoudre mon problème personnel avec l'entreprise" est choisie. Il ne peut plus être mis dans l'arborescence YAML.

Refacto : cette option est refactorée sous forme d'un champ "consumerWish" qui peut prendre plusieurs valeurs différentes (plutôt que les deux booléens contractualDispute/forwardToResponseConso qui se chevauchaient)