### PR TITLE
TRELLO-2079: fix canonical link

### DIFF
--- a/src/app/[lang]/[dynamicPath]/faire-un-signalement/page.tsx
+++ b/src/app/[lang]/[dynamicPath]/faire-un-signalement/page.tsx
@@ -45,11 +45,7 @@ export function generateMetadata(arg: GenerateMetadataArg<LocalPathParams>): Met
           ? m.acknoledgment.sentReport
           : `${m.faireUnSignalement.etape} ${stepParam} ${m.faireUnSignalement.sur} ${reportSteps.length}`
 
-      const landingCanonical = buildLinkLandingPageFromAnomaly(lang, anomaly)
-      const canonical =
-        landingCanonical ??
-        // some anomalies in EN do not have a corresponding landing page
-        buildLinkStartReport(anomaly, lang)
+      const canonical = buildLinkStartReport(anomaly, lang)
       return {
         title: stepSpecificTitle + ' - ' + anomaly.seoTitle + ' - SignalConso',
         description: undefinedIfNull(anomaly.seoDescription ?? anomaly.description),


### PR DESCRIPTION
le lien canonical poussé dans les métadata ne correspond pas à celui de la page.

Par exemple pour :
https://signal.conso.gouv.fr/fr/cafe-restaurant/faire-un-signalement

On a dans les metadata de la page :
`<link rel="canonical" href="https://signal.conso.gouv.fr/fr/cafe-restaurant">`

Du coup je pense que c'est la principale cause de l'erreur suivante :
https://search.google.com/search-console/index/drilldown?resource_id=https%3A%2F%2Fsignal.conso.gouv.fr%2F&item_key=CAMYGCAC&hl=en

Alors qu'on devrait plutôt avoir :

`<link rel="canonical" href="https://signal.conso.gouv.fr/fr/cafe-restaurant/faire-un-signalement">`