### PR TITLE
MEP : TRELLO-2124: Replace UL and LI Tags with P Tags in Accessibility Page…

### DIFF
--- a/src/app/[lang]/accessibilite/page.tsx
+++ b/src/app/[lang]/accessibilite/page.tsx
@@ -107,9 +107,9 @@ const Accessibilite = (props: PageComponentProps) => {
         </ol>
         <h3 className="fr-h3">{m.accessibilite.improvementContactTitle}</h3>
         <p dangerouslySetInnerHTML={{__html: m.accessibilite.improvementContactText}}></p>
-        <ul>
-          <li>{m.accessibilite.supportEmail}</li>
-        </ul>
+
+        <p>{m.accessibilite.supportEmail}</p>
+
         <h2 className="fr-h3">{m.accessibilite.recourseTitle}</h2>
         <p>{m.accessibilite.recourseText}</p>
         <p>{m.accessibilite.recourseOptions}</p>

--- a/src/i18n/localization/fr.ts
+++ b/src/i18n/localization/fr.ts
@@ -328,7 +328,7 @@ export const fr = {
       etape5: 'Étape 5 - Confirmation',
       improvementContactTitle: 'Retour d’information et contact',
       improvementContactText:
-        'Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable du site « <a href="https://signal.conso.gouv.fr/" >« SignalConso »</a> » pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.',
+        'Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable du site « <a href="https://signal.conso.gouv.fr/" > SignalConso </a> » pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.',
       supportEmail: 'E-mail : support@signal.conso.gouv.fr',
       recourseTitle: 'Voie de recours',
       recourseText:


### PR DESCRIPTION
… (#597)

* TRELLO-2124: Replace UL and LI Tags with P Tags in Accessibility Page

* TRELLO-2124:Revert to UL and LI Tags, Except for Email Address in Accessibility Page

* fix format

---------