### PR TITLE
Remove 'intern' from next to your PO's name

### DIFF
--- a/src/core/team.ts
+++ b/src/core/team.ts
@@ -80,7 +80,7 @@ export function getTeam(lang: AppLang): Team {
       },
       {
         name: 'Aline Gauthier',
-        role: [t.function.headOfProductIntern],
+        role: [t.function.headOfProduct],
         avatar: imgAline,
       },
       {


### PR DESCRIPTION
Enlever "stagiaire" à côté du nom de votre PO sur le "qui sommes-nous" de Signal conso!!!