### PR TITLE
Fix repeated barcode search not triggering issue

### DIFF
--- a/src/components_feature/reportFlow/Company/CompanySearchByBarcode.tsx
+++ b/src/components_feature/reportFlow/Company/CompanySearchByBarcode.tsx
@@ -79,8 +79,13 @@ export const CompanySearchByBarcode = ({children}: Props) => {
   function search(form: Form) {
     const cleanedGtin = purgeWhitespaces(form.gtin)
     _analytic.trackEvent(EventCategories.barcodeSearch, CompanySearchEventActions.searchByGTIN, cleanedGtin)
-    setSubmittedGTIN(cleanedGtin)
-    setSubmittedIdentity(undefined)
+    if (cleanedGtin === submittedGTIN) {
+      _searchByBarcode.refetch()
+      _searchByIdentity.refetch()
+    } else {
+      setSubmittedGTIN(cleanedGtin)
+      setSubmittedIdentity(undefined)
+    }
     setSkipped(false)
     setEditing(false)
   }


### PR DESCRIPTION
petit bug, pas très prio je pense

https://demo-signalconso.cleverapps.io/fr/playground?testcase=company_product

Je recherche le code barres 3017620422003

puis je valide, j’obtiens le produit.

puis je clique le crayon pour modifier le champ

finalement, sans rien changer dans le champ, je reclique sur “Rechercher“

=> il ne se passe rien. Le produit devrait être reaffiché.